### PR TITLE
feat: Display scale auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ on otherwise; suspend-on-lid is left to logind, which already gets it right.
 Your bar does not need reloading on monitor change: disabling a screen removes its
 `wl_output` global, so a per-screen shell rebuilds through the normal registry events.
 
-Override the defaults only if you want to:
+Scale is guessed per screen from its physical size and mode.
+Override the defaults only if the guess is wrong or you want a specific arrangement:
 
 ```
 output    = eDP-1, preferred, auto, 2.0    # per-screen mode/position/scale

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -163,11 +163,23 @@ Trailing fields are optional.
 | `NAME` | connector, e.g. `eDP-1`, `DP-1`, `HDMI-A-1` (`wlr-randr` lists them) |
 | `mode` | `preferred` (default), `1920x1080`, `1920x1080@144`, or `disable` |
 | `position` | `auto` (default) or explicit `1920x0` |
-| `scale` | per-output scale; omit to use the global `scale` |
+| `scale` | per-output scale, or `auto` to guess; omit to use the global `scale` |
 
-The global `scale` (default `1.0`, fractional allowed) applies to any output without its
-own. With `auto`, screens pack left-to-right in listed order, so just listing them pins the
-arrangement.
+Scale is resolved in three steps: this output's `scale`, else the global `scale`, else a
+guess from the screen itself. The guess divides the physical size into the mode and
+snaps to `1.0`, `1.5` or `2.0`. Anything 1080p or shorter stays at `1.0`.
+
+The global `scale` defaults to `auto`, so every screen guesses for itself. Set it to a number
+to force one scale everywhere, and give an individual screen `auto` to exempt it:
+
+```
+scale  = 2.0                               # every screen, unless overridden below
+output = DP-1, preferred, auto, auto       # ...except this one, which guesses
+output = HDMI-A-1, preferred, auto, 1.25   # ...and this one, pinned by hand
+```
+
+With position `auto`, screens pack left-to-right in listed order, so just listing them pins
+the arrangement.
 
 ```
 output = eDP-1, preferred, auto, 2.0

--- a/fenriz.conf.example
+++ b/fenriz.conf.example
@@ -12,8 +12,9 @@ gaps             = 8
 rounding         = 10           # corner radius in px
 animation        = 150          # window slide-into-place, ms; 0 = instant (off)
 opacity          = 0.95         # 0.0..1.0
-scale            = 1.0           # default output scale; fractional ok (e.g. 1.5). Per-output
-                                 # `output = ...` scale below overrides it.
+scale            = auto          # auto = guess each screen's scale from its DPI (1x/1.5x/2x).
+                                 # A number here forces every screen to it; the per-output
+                                 # `output = ...` scale below overrides either.
 natural_scroll   = true          # scroll/content follows fingers; false = traditional wheel
 sensitivity      = 0.55          # trackpad/mouse speed, -1.0 (slow) .. 1.0 (fast)
 tap_to_click     = true          # trackpad tap = click; 1/2/3 fingers = left/right/middle
@@ -30,7 +31,7 @@ zoom_step        = 0.1           # fraction of zoom added per scroll notch
 #   NAME      connector name, e.g. eDP-1, DP-1, HDMI-A-1 (`wlr-randr` lists them)
 #   mode      preferred (default) | 1920x1080 | 1920x1080@144 | disable
 #   position  auto (default) | 1920x0   — layout coords of the top-left corner
-#   scale     per-output scale; omit to use the global `scale` above
+#   scale     per-output scale | auto (guess from DPI); omit to use the global `scale` above
 #
 # With `auto`, screens are packed left-to-right in the order they're listed here, so
 # listing them is enough to pin the arrangement — no need for explicit coordinates.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -217,7 +217,7 @@ namespace fenriz {
                 if (parts.size() > 2 && !parts[2].empty())
                     o.position = parts[2];
                 if (parts.size() > 3 && !parts[3].empty())
-                    o.scale = parse_float(parts[3], o.scale, 0.25f, 10.0f);
+                    o.scale = parts[3] == "auto" ? -1.0f : parse_float(parts[3], o.scale, 0.25f, 10.0f);
                 cfg.outputs.push_back(o);
                 continue;
             }
@@ -298,7 +298,7 @@ namespace fenriz {
             else if (key == "opacity")
                 cfg.opacity = parse_float(val, cfg.opacity, 0.0f, 1.0f);
             else if (key == "scale")
-                cfg.scale = parse_float(val, cfg.scale, 0.25f, 10.0f);
+                cfg.scale = val == "auto" ? 0.0f : parse_float(val, cfg.scale, 0.25f, 10.0f);
             else if (key == "natural_scroll")
                 cfg.natural_scroll = parse_bool(val, cfg.natural_scroll);
             else if (key == "tap_to_click")

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -52,7 +52,7 @@ namespace fenriz {
         std::string name;
         std::string mode = "preferred"; // "preferred" | "1920x1080" | "1920x1080@60" | "disable"
         std::string position = "auto";  // "auto" | "1920x0" (layout coords)
-        float scale = 0;                // 0 = fall back to Config::scale
+        float scale = 0;                // 0 = fall back to Config::scale, -1 = guess from DPI
     };
 
     struct Config {
@@ -67,7 +67,7 @@ namespace fenriz {
         int rounding = 10;
         int animation_ms = 150; // slide-into-place duration; 0 = instant (no animation)
         float opacity = 1.0f;
-        float scale = 1.0f;                // output scale; fractional (e.g. 1.5) supported, 1.0 = off
+        float scale = 0;                   // output scale for screens with no `output =` scale; 0 = guess from DPI
         bool natural_scroll = true;        // libinput scroll direction; false = traditional wheel
         float sensitivity = 0.0f;          // libinput pointer accel speed, -1.0 (slow) .. 1.0 (fast); 0 = default
         bool tap_to_click = true;          // trackpad tap = click (1/2/3 fingers = left/right/middle)

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -36,7 +36,7 @@ namespace fenriz::layer {
             if (ls->handle->output) {
                 wlr_surface_send_enter(surface, ls->handle->output);
                 if (output::Output* o = output::by_handle(*ls->server, ls->handle->output))
-                    wlr_fractional_scale_v1_notify_scale(surface, output::scale_of(*ls->server, o));
+                    wlr_fractional_scale_v1_notify_scale(surface, output::scale_of(o));
             }
 
             // Never let a layer surface grab the keyboard while locked

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -302,13 +302,15 @@ namespace fenriz::output {
             return hit;
         }
 
-        // Commit mode + scale from config (or the preferred mode / global scale fallback).
+        // commit mode + scale from this output's config, falling back to the preferred mode or guess
         void commit_mode(Server& server, Output* o) {
             const OutputCfg* cfg = config_for(server, name_of(o));
 
             wlr_output_state state;
             wlr_output_state_init(&state);
             wlr_output_state_set_enabled(&state, true);
+
+            int px_w = o->handle->width, px_h = o->handle->height;
 
             bool mode_set = false;
             if (cfg && !cfg->mode.empty() && cfg->mode != "preferred" && cfg->mode != "disable") {
@@ -326,13 +328,13 @@ namespace fenriz::output {
                         if (!best || m->refresh > best->refresh)
                             best = m;
                     }
-                    if (best) {
+                    if (best)
                         wlr_output_state_set_mode(&state, best);
-                        mode_set = true;
-                    } else {
+                    else
                         wlr_output_state_set_custom_mode(&state, w, h, hz > 0 ? (int)(hz * 1000) : 0);
-                        mode_set = true;
-                    }
+                    mode_set = true;
+                    px_w = w;
+                    px_h = h;
                 }
                 if (!mode_set)
                     wlr_log(WLR_ERROR,
@@ -341,14 +343,27 @@ namespace fenriz::output {
                             cfg->mode.c_str());
             }
             if (!mode_set)
-                if (wlr_output_mode* mode = wlr_output_preferred_mode(o->handle))
+                if (wlr_output_mode* mode = wlr_output_preferred_mode(o->handle)) {
                     wlr_output_state_set_mode(&state, mode);
+                    px_w = mode->width;
+                    px_h = mode->height;
+                }
 
-            // Per-output scale, falling back to the global config.scale (pre-multi-output
-            // configs keep working).
-            const float scale = cfg && cfg->scale > 0 ? cfg->scale : server.config.scale;
-            if (scale > 0)
-                wlr_output_state_set_scale(&state, scale);
+            float scale = cfg ? cfg->scale : 0;
+            if (scale == 0)
+                scale = server.config.scale;
+            if (scale <= 0) {
+                scale = guess_scale(o->handle->phys_width, o->handle->phys_height, px_w, px_h);
+                wlr_log(WLR_INFO,
+                        "fenriz: output %s: %dx%d at %dx%dmm, guessed scale %.2f",
+                        name_of(o).c_str(),
+                        px_w,
+                        px_h,
+                        o->handle->phys_width,
+                        o->handle->phys_height,
+                        scale);
+            }
+            wlr_output_state_set_scale(&state, scale);
 
             // Say so loudly if the driver rejects it: a silently-dropped commit leaves the
             // screen on whatever the firmware set, which looks like "my scale config is
@@ -521,12 +536,7 @@ namespace fenriz::output {
 
     std::string name_of(const Output* o) { return o && o->handle && o->handle->name ? o->handle->name : ""; }
 
-    float scale_of(Server& server, const Output* o) {
-        const OutputCfg* cfg = config_for(server, name_of(o));
-        if (cfg && cfg->scale > 0)
-            return cfg->scale;
-        return server.config.scale > 0 ? server.config.scale : 1.0f;
-    }
+    float scale_of(const Output* o) { return o && o->handle && o->handle->scale > 0 ? o->handle->scale : 1.0f; }
 
     Output* by_name(Server& server, const std::string& name) {
         for (Output* o : server.outputs)

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -69,6 +69,9 @@ namespace fenriz {
         // is_internal(). Use this, not is_internal, for policy decisions.
         bool lid_controls(Server& server, const Output* o);
 
+        // Scale for a screen with no configured one
+        float guess_scale(int phys_w_mm, int phys_h_mm, int px_w, int px_h);
+
         // The area windows may occupy on `o`, in layout coordinates: the usable area left by
         // this output's exclusive zones (bars), falling back to its full box before any layer
         // surface has reserved space. Empty box for a null output.
@@ -175,8 +178,8 @@ namespace fenriz {
         Output* by_name(Server& server, const std::string& name);
         Output* by_handle(Server& server, const wlr_output* handle);
 
-        // This output's effective scale: its `output = ...` entry, else the global `scale`.
-        float scale_of(Server& server, const Output* o);
+        // This output's effective scale
+        float scale_of(const Output* o);
 
         // The output that should receive new windows / layer surfaces: the focused view's
         // output, else the one under the cursor, else the first. Derived, never stored — one

--- a/src/output_policy.cpp
+++ b/src/output_policy.cpp
@@ -1,16 +1,38 @@
-// The pure half of output management: which output each workspace belongs on, and what counts
-// as a lid-controlled panel. No wlroots, no compositor state, output.cpp maps the result back
-// onto real outputs. Split out so test_output.cpp can link it without a display.
+// The pure half of output management: which output each workspace belongs on, what counts as a
+// lid-controlled panel, and what scale a screen wants. No wlroots, no compositor state,
+// output.cpp maps the result back onto real outputs. Split out so test_output.cpp can link it
+// without a display.
 
 #include "output.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 namespace fenriz::output {
 
     bool is_internal(const std::string& name) {
         // wlroots exposes no "built-in panel" bit, so go by connector name like sway/Hyprland.
         return name.rfind("eDP-", 0) == 0 || name.rfind("LVDS-", 0) == 0 || name.rfind("DSI-", 0) == 0;
+    }
+
+    float guess_scale(int phys_w_mm, int phys_h_mm, int px_w, int px_h) {
+        if (phys_w_mm <= 0 || phys_h_mm <= 0 || px_w <= 0 || px_h <= 0)
+            return 1.0f;
+
+        // EDIDs lie (projector, TV)
+        const double diag_mm = std::hypot((double)phys_w_mm, (double)phys_h_mm);
+        if (diag_mm < 100.0)
+            return 1.0f;
+
+        if (px_h < 1200)
+            return 1.0f;
+
+        const double dpi = std::hypot((double)px_w, (double)px_h) / (diag_mm / 25.4);
+        if (dpi >= 192.0)
+            return 2.0f;
+        if (dpi >= 144.0)
+            return 1.5f;
+        return 1.0f;
     }
 
     void assign_workspaces(const std::string home[WS_COUNT],

--- a/src/test_config.cpp
+++ b/src/test_config.cpp
@@ -108,7 +108,11 @@ int main() {
     // Garbage leaves the default intact (stof throws, value untouched).
     Config junk = Config::parse("opacity = abc\nscale = \n");
     assert(junk.opacity == 1.0f);
-    assert(junk.scale == 1.0f);
+    assert(junk.scale == 0.0f);
+
+    assert(Config().scale == 0.0f);
+    assert(Config::parse("scale = auto\n").scale == 0.0f);
+    assert(Config::parse("scale = 1.5\n").scale == 1.5f);
 
     // Per-output config. Trailing fields are optional and fall back to preferred/auto/global
     // scale, so a bare `output = NAME` is valid.
@@ -123,6 +127,10 @@ int main() {
     assert(out.outputs[2].mode == "disable");
     // Unspecified fields keep their defaults; scale 0 means "fall back to the global scale".
     assert(out.outputs[3].mode == "preferred" && out.outputs[3].position == "auto" && out.outputs[3].scale == 0);
+
+    Config autos = Config::parse("scale = 2.0\noutput = DP-1, preferred, auto, auto\n");
+    assert(autos.scale == 2.0f);
+    assert(autos.outputs[0].scale == -1.0f);
 
     // Workspace homes are 1-indexed in the config, 0-indexed in the array. Out-of-range is
     // ignored rather than writing past the end.

--- a/src/test_output.cpp
+++ b/src/test_output.cpp
@@ -298,6 +298,18 @@ int main() {
     assert(!is_internal("HDMI-A-1"));
     assert(!is_internal(""));
 
+    assert(guess_scale(290, 190, 2880, 1920) == 2.0f);  // 13.5" laptop panel, 253 dpi
+    assert(guess_scale(1190, 340, 3840, 1080) == 1.0f); // 49" 32:9 ultrawide, 82 dpi
+    assert(guess_scale(600, 340, 3840, 2160) == 1.5f);  // 27" 4K, 163 dpi
+    assert(guess_scale(600, 340, 2560, 1440) == 1.0f);  // 27" 1440p, 109 dpi
+    assert(guess_scale(1600, 900, 3840, 2160) == 1.0f); // 72" TV, 61 dpi
+
+    assert(guess_scale(0, 0, 2880, 1920) == 1.0f);
+    assert(guess_scale(160, 90, 1920, 1080) == 1.0f); // implausibly small "monitor"
+    assert(guess_scale(-1, -1, 2880, 1920) == 1.0f);
+    assert(guess_scale(290, 190, 0, 0) == 1.0f); // no mode yet
+    assert(guess_scale(100, 60, 1920, 1080) == 1.0f);
+
     printf("test_output: ok\n");
     return 0;
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -839,7 +839,7 @@ namespace fenriz {
         }
 
         if (o)
-            wlr_fractional_scale_v1_notify_scale(surface, output::scale_of(server, o));
+            wlr_fractional_scale_v1_notify_scale(surface, output::scale_of(o));
     }
 
     void focus_topmost_visible(Server& server) {


### PR DESCRIPTION
If the `scale` config property is set to `auto` fenriz will try and guess the appropriate scale for the output. The guess is pretty easy for "normal" monitors but gets trickier with projectors and TVs and may not be right. `scale` can still be set manually in these cases. 

Previously, if per-output was not configured explicitly with a scale it would apply to all outputs. So a 2x laptop display set to `scale = 2` would also 2x scale all attached montiors (usually they aren't 2x).