### PR TITLE
feat: cursor management

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,8 @@ make install      # install to /usr/local/bin/fenriz
 fenriz            # launch the compositor (from a greeter, TTY, or inside an existing Wayland session)
 ```
 
-Logs go to stderr and to `$XDG_STATE_HOME/fenriz/fenriz.log` (default
-`~/.local/state/fenriz/fenriz.log`), so a session started by a greeter still leaves something
-readable behind. The previous run is kept as `fenriz.log.1`. Override the path with
-`FENRIZ_LOG=<path>`, raise the level with `FENRIZ_DEBUG=1`. For the journal instead, launch it
-as `systemd-cat -t fenriz fenriz`.
+Logs go to stderr and to `$XDG_STATE_HOME/fenriz/fenriz.log` (default `~/.local/state/fenriz/fenriz.log`).
+Override the path with `FENRIZ_LOG=<path>`, raise the level with `FENRIZ_DEBUG=1`.
 
 ## Multi-monitor and clamshell
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -139,6 +139,10 @@ Colors are `0xRRGGBBAA` hex.
 | `focus_follows_pointer` | `true` | hovering focuses; `false` = click to focus |
 | `repeat_delay` | `250` | ms before a held key repeats |
 | `repeat_rate` | `15` | key repeats per second |
+| `cursor` | unset | cursor theme name (a directory under `/usr/share/icons` or `~/.local/share/icons`); unset = `XCURSOR_THEME` from the environment, then the system `default` theme |
+| `cursor_size` | `24` | cursor base size in px at scale 1; `0`/unset = `XCURSOR_SIZE`, then `24` |
+
+`cursor` and `cursor_size` are exported as `XCURSOR_THEME`/`XCURSOR_SIZE`, so clients and XWayland apps draw the same cursor the compositor does.
 
 ### Zoom
 

--- a/fenriz.conf.example
+++ b/fenriz.conf.example
@@ -20,6 +20,10 @@ sensitivity      = 0.55          # trackpad/mouse speed, -1.0 (slow) .. 1.0 (fas
 tap_to_click     = true          # trackpad tap = click; 1/2/3 fingers = left/right/middle
 clickfinger      = true          # two-finger press = right-click; false = bottom-right corner
 focus_follows_pointer = true     # window under the moving cursor gains focus; false = click-to-focus only
+# cursor         = BreezeX-RosePine-Linux  # icon theme name under /usr/share/icons or ~/.local/share/icons.
+                                 # Unset = XCURSOR_THEME from the environment, then the system default.
+                                 # Exported to clients too, so apps match the compositor's pointer.
+# cursor_size    = 24            # base size in px at scale 1; unset = XCURSOR_SIZE, then 24
 
 # Screen zoom / magnifier: hold zoom_mod and scroll to zoom in/out around the cursor.
 zoom_mod         = ctrl          # ctrl / alt / super / shift; empty or unknown = off

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -317,6 +317,10 @@ namespace fenriz {
                 cfg.repeat_rate = parse_int(val, cfg.repeat_rate, 1, 1000); // lower bound avoids /0 in timer
             else if (key == "zoom_mod")
                 cfg.zoom_mod = mod_from_token(val); // "ctrl"/"alt"/"super"/"shift"; unknown = 0 = off
+            else if (key == "cursor")
+                cfg.cursor_theme = val;
+            else if (key == "cursor_size")
+                cfg.cursor_size = parse_int(val, cfg.cursor_size, 0, 256); // 0 = auto, like `scale`
             else if (key == "zoom_max")
                 cfg.zoom_max = parse_float(val, cfg.zoom_max, 1.0f, 10.0f);
             else if (key == "zoom_step")

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -75,6 +75,8 @@ namespace fenriz {
         bool focus_follows_pointer = true; // window under the moving cursor gains focus
         int repeat_delay = 250;            // ms a `binde` key is held before it starts repeating
         int repeat_rate = 15;              // `binde` fires per second while held
+        std::string cursor_theme;
+        int cursor_size = 0;
         uint32_t zoom_mod = 4;  // modifier + scroll = screen zoom; 4 = CTRL (mirrors WLR_MODIFIER_*), 0 = off
         float zoom_max = 3.0f;  // ceiling for the zoom level
         float zoom_step = 0.1f; // fraction of zoom added/removed per scroll notch

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -1,7 +1,9 @@
 #include "cursor.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <linux/input-event-codes.h>
+#include <string>
 
 #include "layer.hpp"
 #include "server.hpp"
@@ -46,6 +48,9 @@ namespace fenriz::cursor {
             wlr_pointer_constraint_v1* active = nullptr;
             wl_listener constraint_destroy; // linked only while `active` is set
 
+            std::string theme;
+            int size = 0;
+
             Grab grab = Grab::None;
             View* grabbed = nullptr;
             View* preview_partner = nullptr;     // tiled view swapped into grabbed's home slot (live drag rearrange)
@@ -56,6 +61,39 @@ namespace fenriz::cursor {
 
         // The singleton, so forget_view() can reach the grab state (init() sets it).
         Cursor* g_cursor = nullptr;
+
+        // (Re)build the xcursor manager. Theme and size come from `cursor =` / `cursor_size =`,
+        // falling back to XCURSOR_THEME/XCURSOR_SIZE in the environment, then to the system
+        // "default" theme at 24px. Exported as XCURSOR_THEME/XCURSOR_SIZE for clients.
+        void load_theme(Cursor* c) {
+            const Config& cfg = c->server->config;
+            std::string theme = cfg.cursor_theme;
+            if (theme.empty())
+                if (const char* e = getenv("XCURSOR_THEME"))
+                    theme = e;
+            int size = cfg.cursor_size;
+            if (size <= 0) {
+                const char* e = getenv("XCURSOR_SIZE");
+                size = e ? (int)strtol(e, nullptr, 10) : 0;
+                if (size <= 0)
+                    size = 24;
+            }
+            if (c->mgr && theme == c->theme && size == c->size)
+                return;
+
+            wlr_xcursor_manager* old = c->mgr;
+            c->mgr = wlr_xcursor_manager_create(theme.empty() ? nullptr : theme.c_str(), size);
+            c->theme = theme;
+            c->size = size;
+            wlr_cursor_set_xcursor(c->cursor, c->mgr, "default");
+            if (old)
+                wlr_xcursor_manager_destroy(old);
+
+            if (!theme.empty())
+                setenv("XCURSOR_THEME", theme.c_str(), 1);
+            setenv("XCURSOR_SIZE", std::to_string(size).c_str(), 1);
+            wlr_log(WLR_INFO, "fenriz: cursor theme '%s' at %dpx", theme.empty() ? "default" : theme.c_str(), size);
+        }
 
         // Surface under (lx,ly) via the scene graph, honoring z-order. While locked, only
         // the lock tree is considered so input can't reach the desktop. *sx,*sy return
@@ -292,9 +330,12 @@ namespace fenriz::cursor {
                                ? wlr_pointer_constraints_v1_constraint_for_surface(c->constraints, surface, server.seat)
                                : nullptr);
 
-            if (!surface) {
-                // Over empty desktop: show the default cursor and drop pointer focus.
+            // dont reset the cursor on dnd
+            if (!server.seat->drag && surface != server.seat->pointer_state.focused_surface)
                 wlr_cursor_set_xcursor(c->cursor, c->mgr, "default");
+
+            if (!surface) {
+                // Over empty desktop: nothing holds pointer focus.
                 wlr_seat_pointer_notify_clear_focus(server.seat);
                 return;
             }
@@ -434,6 +475,7 @@ namespace fenriz::cursor {
                             rc = top ? (left ? "nw-resize" : "ne-resize") : (left ? "sw-resize" : "se-resize");
                         }
                         wlr_cursor_set_xcursor(c->cursor, c->mgr, rc);
+                        wlr_seat_pointer_notify_clear_focus(server.seat);
                         return; // consume the press; don't forward to the client
                     }
                 }
@@ -616,10 +658,7 @@ namespace fenriz::cursor {
         c->cursor = wlr_cursor_create();
         server.cursor = c->cursor;
         wlr_cursor_attach_output_layout(c->cursor, server.output_layout);
-        c->mgr = wlr_xcursor_manager_create(nullptr, 24);
-        // Load the cursor theme at the output scale so the pointer isn't a tiny 1x sprite.
-        if (server.config.scale > 0)
-            wlr_xcursor_manager_load(c->mgr, server.config.scale);
+        load_theme(c);
 
         add_listener(c->motion, c->cursor->events.motion, cursor_motion);
         add_listener(c->motion_absolute, c->cursor->events.motion_absolute, cursor_motion_absolute);
@@ -655,6 +694,11 @@ namespace fenriz::cursor {
         // Cursor is value-initialized, so this link is {null,null}, not a valid empty list. Init it
         // so set_constraint's unconditional wl_list_remove is safe before the first constraint.
         wl_list_init(&c->constraint_destroy.link);
+    }
+
+    void reload(Server&) {
+        if (g_cursor)
+            load_theme(g_cursor);
     }
 
     void attach_pointer(Server& server, wlr_input_device* device) {

--- a/src/cursor.hpp
+++ b/src/cursor.hpp
@@ -13,6 +13,8 @@ namespace fenriz {
     namespace cursor {
         // Create the cursor + xcursor manager and wire pointer/seat events.
         void init(Server& server);
+        // Re-apply the configured cursor theme/size after a config reload.
+        void reload(Server& server);
         // Route a newly-attached pointer device's motion through the cursor.
         void attach_pointer(Server& server, wlr_input_device* device);
         // Cancel any interactive grab on `view` (called when it unmaps, before it's freed,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -505,6 +505,10 @@ namespace fenriz {
         wlr_data_control_manager_v1_create(display);
         wlr_ext_data_control_manager_v1_create(display, 1);
 
+        // Export configured env vars (QT_QPA_PLATFORMTHEME, XCURSOR_THEME) before anything reads the environment
+        for (const auto& [name, value] : config.env)
+            setenv(name.c_str(), value.c_str(), 1);
+
         // XWayland: managed X11 toplevels. Needs the compositor + seat (both live now), and
         // exports DISPLAY so exec-once X clients (run below) can find it.
         xwayland::setup(*this);
@@ -583,12 +587,6 @@ namespace fenriz {
         // Hot-reload: apply edits to fenriz.conf live (no restart). See init_config_watch.
         init_config_watch(*this, loop);
 
-        // Export configured env vars (QT_QPA_PLATFORMTHEME) before spawning anything,
-        // so exec-once clients inherit them. Set after WAYLAND_DISPLAY/FENRIZ_SOCKET so a
-        // stray `env` line can't shadow those.
-        for (const auto& [name, value] : config.env)
-            setenv(name.c_str(), value.c_str(), 1);
-
         // Run startup commands now that the socket is live and WAYLAND_DISPLAY is set,
         // so the spawned clients connect to us.
         for (const std::string& cmd : config.exec_once)
@@ -619,6 +617,7 @@ namespace fenriz {
         // Re-apply output mode/scale/position and workspace homes, then re-home + re-arrange.
         // Editing an `output =` line takes effect live, no restart.
         output::apply_config(server);
+        cursor::reload(server); // `cursor =` / `cursor_size =` re-theme the pointer live
         for (View* v : server.views)
             place_view_nodes(v); // border width/color/rounding on all views (incl. floating)
         wlr_log(WLR_INFO, "fenriz: config reloaded");

--- a/src/test_config.cpp
+++ b/src/test_config.cpp
@@ -23,6 +23,8 @@ int main() {
                        "bind = SUPER SHIFT, E, exit\n"
                        "bind = SUPER, 2, workspace, 3\n"
                        "bind = SUPER SHIFT, 4, movetoworkspace, 5\n"
+                       "cursor = catppuccin-mocha-mauve-cursors\n"
+                       "cursor_size = 32\n"
                        "repeat_delay = 300\n"
                        "repeat_rate = 20\n"
                        "zoom_mod = alt\n"
@@ -56,6 +58,13 @@ int main() {
 
     assert(c.repeat_delay == 300);
     assert(c.repeat_rate == 20);
+
+    assert(c.cursor_theme == "catppuccin-mocha-mauve-cursors");
+    assert(c.cursor_size == 32);
+    // Unset means "ask the environment", which only cursor.cpp can resolve.
+    assert(Config{}.cursor_theme.empty() && Config{}.cursor_size == 0);
+    // A negative size would reach wlr_xcursor_manager_create as a huge unsigned; clamp to auto.
+    assert(Config::parse("cursor_size = -8\n").cursor_size == 0);
 
     assert(c.zoom_mod == 8u); // "alt" -> WLR_MODIFIER_ALT bit
     assert(c.zoom_max > 3.99f && c.zoom_max < 4.01f);


### PR DESCRIPTION
Two changes:
- feat: cursor management in the config. Make it easier for users to keep the compositors cursor and GTK/KDE/XWayland cursor in sync. If set, the compositor's own cursor uses it and exports the env vars needed (XCURSOR_*)
- fix: cursor shape not reset when it should be. Drag and Drop, for example would not reset the shape from drag-hand to pointer when released. 