### PR TITLE
fix: zoom natural scrolling and jerkiness

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -146,7 +146,7 @@ Colors are `0xRRGGBBAA` hex.
 
 ### Zoom
 
-Hold `zoom_mod` and scroll to magnify around the cursor.
+Hold `zoom_mod` and scroll to magnify around the cursor. Scrolling up zooms in and down zooms out.
 
 | Key | Default | Meaning |
 |---|---|---|

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -508,8 +508,7 @@ namespace fenriz::cursor {
 
             process_motion(c, event->time_msec); // rebase pointer focus; see cursor_button
 
-            // Modifier + scroll = screen zoom (default CTRL, configurable via zoom_mod).
-            // The compositor consumes the event: the client never sees it.
+            // zoom_mod + scroll = screen zoom
             const uint32_t zmod = server.config.zoom_mod;
             wlr_keyboard* kb = wlr_seat_get_keyboard(server.seat);
             const uint32_t mods = kb ? wlr_keyboard_get_modifiers(kb) : 0;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -507,8 +507,11 @@ namespace fenriz::cursor {
             const uint32_t mods = kb ? wlr_keyboard_get_modifiers(kb) : 0;
             if (zmod != 0 && (mods & zmod) && event->delta != 0) {
                 const float step = server.config.zoom_step;
-                // Scroll up (negative delta) zooms in, down zooms out
-                float f = event->delta < 0 ? (1.0f + step) : (1.0f / (1.0f + step));
+                // zoom scrolling up/away always zooms in regardless of natural_scroll
+                float delta = event->delta;
+                if (event->relative_direction == WL_POINTER_AXIS_RELATIVE_DIRECTION_INVERTED)
+                    delta = -delta;
+                float f = delta < 0 ? (1.0f + step) : (1.0f / (1.0f + step));
                 server.zoom_target = std::clamp(server.zoom_target * f, 1.0f, server.config.zoom_max);
                 schedule_frame_at_cursor(c);
                 return;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -493,6 +493,14 @@ namespace fenriz::cursor {
             wlr_seat_pointer_notify_button(server.seat, event->time_msec, event->button, event->state);
         }
 
+        // True if libinput is inverting this device's scroll deltas
+        bool device_natural_scroll(wlr_input_device* device) {
+            if (!wlr_input_device_is_libinput(device))
+                return false;
+            libinput_device* dev = wlr_libinput_get_device_handle(device);
+            return dev && libinput_device_config_scroll_get_natural_scroll_enabled(dev);
+        }
+
         void cursor_axis(wl_listener* listener, void* data) {
             Cursor* c = wl_container_of(listener, c, axis);
             Server& server = *c->server;
@@ -509,7 +517,7 @@ namespace fenriz::cursor {
                 const float step = server.config.zoom_step;
                 // zoom scrolling up/away always zooms in regardless of natural_scroll
                 float delta = event->delta;
-                if (event->relative_direction == WL_POINTER_AXIS_RELATIVE_DIRECTION_INVERTED)
+                if (device_natural_scroll(&event->pointer->base))
                     delta = -delta;
                 float f = delta < 0 ? (1.0f + step) : (1.0f / (1.0f + step));
                 server.zoom_target = std::clamp(server.zoom_target * f, 1.0f, server.config.zoom_max);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -110,25 +110,21 @@ namespace fenriz::output {
             }
             wlr_texture* tex = wlr_texture_from_buffer(server.renderer, scene_state.buffer);
 
-            // Zoom viewport, centered on the cursor and clamped to the output.
+            // Zoom viewport
             wlr_box lb; // output box in layout coords (== effective resolution)
             wlr_output_layout_get_box(server.output_layout, handle, &lb);
             const double z = server.zoom;
-            double cx = std::clamp(server.cursor->x - lb.x, 0.0, (double)lb.width);
-            double cy = std::clamp(server.cursor->y - lb.y, 0.0, (double)lb.height);
-            double vw = lb.width / z, vh = lb.height / z;
-            double vx = std::clamp(cx - vw / 2, 0.0, lb.width - vw);
-            double vy = std::clamp(cy - vh / 2, 0.0, lb.height - vh);
-            // src_box is in buffer pixels; buffer may be larger than layout box under output scale.
+            const double cx = std::clamp(server.cursor->x - lb.x, 0.0, (double)lb.width);
+            const double cy = std::clamp(server.cursor->y - lb.y, 0.0, (double)lb.height);
+            const double vw = lb.width / z, vh = lb.height / z;
+            const double vx = zoom_viewport_origin(cx, z);
+            const double vy = zoom_viewport_origin(cy, z);
             const double sx = (double)handle->width / lb.width, sy = (double)handle->height / lb.height;
 
             wlr_output_state out_state;
             wlr_output_state_init(&out_state);
             if (tex) {
                 if (wlr_render_pass* pass = wlr_output_begin_render_pass(handle, &out_state, nullptr)) {
-                    // Plain textured blit — no SceneFX effects needed on the zoom, and its
-                    // pass.h is un-includable here (pulls a private egl.h). The fx_renderer
-                    // still services this base wlr_render_pass call.
                     wlr_render_texture_options o = {};
                     o.texture = tex;
                     o.src_box = {vx * sx, vy * sy, vw * sx, vh * sy};

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -78,6 +78,10 @@ namespace fenriz {
         // Scale for a screen with no configured one
         float guess_scale(int phys_w_mm, int phys_h_mm, int px_w, int px_h);
 
+        // Origin of the magnifier viewport along one axis, given the cursor's offset `c` into the output on that axis
+        // and zoom level `z >= 1`.
+        double zoom_viewport_origin(double c, double z);
+
         // The area windows may occupy on `o`, in layout coordinates: the usable area left by
         // this output's exclusive zones (bars), falling back to its full box before any layer
         // surface has reserved space. Empty box for a null output.

--- a/src/output_policy.cpp
+++ b/src/output_policy.cpp
@@ -35,6 +35,8 @@ namespace fenriz::output {
         return 1.0f;
     }
 
+    double zoom_viewport_origin(double c, double z) { return z > 1.0 ? c * (1.0 - 1.0 / z) : 0.0; }
+
     void assign_workspaces(const std::string home[WS_COUNT],
                            const bool needed[WS_COUNT],
                            const std::vector<std::string>& live,

--- a/src/test_output.cpp
+++ b/src/test_output.cpp
@@ -4,6 +4,7 @@
 #include "output.hpp"
 
 #include <cassert>
+#include <cmath>
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -309,6 +310,21 @@ int main() {
     assert(guess_scale(-1, -1, 2880, 1920) == 1.0f);
     assert(guess_scale(290, 190, 0, 0) == 1.0f); // no mode yet
     assert(guess_scale(100, 60, 1920, 1080) == 1.0f);
+
+    {
+        const double W = 1920;
+        for (double z : {1.0, 1.01, 1.5, 2.0, 3.0, 10.0}) {
+            const double vw = W / z;
+            for (double c : {0.0, 1.0, 640.0, 960.0, 1279.0, W}) {
+                const double v = zoom_viewport_origin(c, z);
+                assert(std::abs((c - v) / vw * W - c) < 1e-9); // pointer's point is a fixed point
+                assert(v >= 0.0 && v <= W - vw + 1e-9);        // in range without clamping
+            }
+        }
+        assert(zoom_viewport_origin(1234.0, 1.0) == 0.0);
+        assert(zoom_viewport_origin(0.0, 4.0) == 0.0);
+        assert(std::abs(zoom_viewport_origin(W, 4.0) - (W - W / 4)) < 1e-9);
+    }
 
     printf("test_output: ok\n");
     return 0;


### PR DESCRIPTION
Zoom followed the inversion of `natural_scroll` which is weird. Everything uses up = zoom in, down = zoom out regarless of "natural scroll" on trackpads. This fixes that.

Also, the math was wrong on zoom location. It followed the "relative" position of the cursor rather than it being a fixed point. This caused jerkiness while zooming.