### PR TITLE
fix: fable memory audit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,13 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Memory audits: cmake --preset sanitize
+option(FENRIZ_SANITIZE "Build with AddressSanitizer + UndefinedBehaviorSanitizer" OFF)
+if(FENRIZ_SANITIZE)
+    add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer -g -UNDEBUG)
+    add_link_options(-fsanitize=address,undefined)
+endif()
+
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(SCENEFX   REQUIRED IMPORTED_TARGET scenefx-0.5)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,6 +17,18 @@
       }
     },
     {
+      "name": "sanitize",
+      "displayName": "Sanitizer Build (Ninja, ASan+UBSan)",
+      "description": "Debug build with address/undefined sanitizers, for memory audits",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/sanitize",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "FENRIZ_SANITIZE": "ON"
+      }
+    },
+    {
       "name": "release",
       "displayName": "Release Build (Ninja)",
       "description": "Ninja Release build inside build/release",
@@ -33,6 +45,10 @@
     {
       "name": "debug",
       "configurePreset": "debug"
+    },
+    {
+      "name": "sanitize",
+      "configurePreset": "sanitize"
     },
     {
       "name": "release",

--- a/scripts/lsan-suppressions.txt
+++ b/scripts/lsan-suppressions.txt
@@ -1,0 +1,40 @@
+# LeakSanitizer suppressions for `cmake --preset sanitize` runs.
+#
+# Everything here is allocated once and deliberately never freed, because fenriz exits by
+# ending the process. They are real allocations, just not real leaks — without this file they
+# bury the findings that matter. See ~Server in src/server.cpp for why teardown is skipped
+# (wlroots' globals assert if anything is still subscribed to their signals at destroy).
+#
+# Usage:
+#   LSAN_OPTIONS=suppressions=scripts/lsan-suppressions.txt:print_suppressions=0 \
+#   ASAN_OPTIONS=detect_leaks=1 ./build/sanitize/fenriz
+#
+# If you add a suppression, say WHY it can never be a real leak. A suppression that hides a
+# per-event allocation is how a leak audit ends up proving nothing.
+
+# --- fenriz session singletons: one per process, freed by exit ---
+# NOT ipc::init — a `leak:fenriz::ipc::init` line here hid a genuinely fixable leak (its
+# listen-socket event source) until valgrind, which has no such suppression, found it.
+# ipc::shutdown() now cleans up, so nothing there needs suppressing. Cautionary tale:
+# suppress the narrowest thing that is truly unfixable, never a whole init function.
+leak:fenriz::cursor::init
+leak:fenriz::lock::init
+
+# --- compositor-lifetime wlroots/scenefx objects (~Server leaves these up on purpose) ---
+leak:wlr_backend_autocreate
+leak:wlr_allocator_autocreate
+leak:fx_renderer_create
+leak:wlr_xwayland_create
+leak:wlr_scene_create
+
+# --- graphics stack: mesa/GL/EGL/DRM keep process-lifetime caches and TLS ---
+leak:libEGL
+leak:libGLESv2
+leak:swrast_dri.so
+leak:libgallium
+leak:radeonsi_dri.so
+leak:libdrm
+
+# --- fontconfig / xkbcommon one-time caches ---
+leak:libfontconfig
+leak:xkb_context_new

--- a/scripts/mem-stress.sh
+++ b/scripts/mem-stress.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Drive a NESTED fenriz through the state transitions that allocate and free, then report
+# whether RSS settled. This is the harness the memory audit's findings are measured against:
+# reading the code tells you a buffer is retained, this tells you by how much.
+#
+#   ./scripts/mem-stress.sh [cycles]            # plain debug build, RSS delta
+#   ./scripts/mem-stress.sh 20 sanitize         # ASan/LSan/UBSan build
+#   ./scripts/mem-stress.sh 5 valgrind          # memcheck (slow; use few cycles)
+#   ./scripts/mem-stress.sh 20 heaptrack        # allocation profile
+#
+# Never run against the live session: it always starts its own nested compositor on the
+# wayland backend, and always reads that instance's socket out of its OWN log rather than
+# globbing $XDG_RUNTIME_DIR (which would find the real one).
+
+set -u
+
+CYCLES=${1:-10}
+MODE=${2:-plain}
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+OUT=$(mktemp -d /tmp/fenriz-memstress.XXXXXX)
+LOG=$OUT/fenriz.log
+
+case $MODE in
+    sanitize) BIN=$ROOT/build/sanitize/fenriz; PRESET=sanitize ;;
+    *)        BIN=$ROOT/build/debug/fenriz;    PRESET=debug ;;
+esac
+
+[ -x "$BIN" ] || { echo "missing $BIN — run: cmake --preset $PRESET && cmake --build --preset $PRESET"; exit 1; }
+[ -n "${WAYLAND_DISPLAY:-}" ] || { echo "no host WAYLAND_DISPLAY; this must run inside a Wayland session"; exit 1; }
+command -v socat >/dev/null || { echo "socat required"; exit 1; }
+# Two nested instances land on the same WAYLAND_DISPLAY, hence the same control socket, and
+# silently drive each other's commands. Refuse to start rather than produce a bogus number.
+# Anchored at both ends so it matches only the nested binary itself — not the user's live
+# /usr/bin/fenriz, and not a shell whose command line happens to contain the path.
+if pgrep -f "^${ROOT}/build/[a-z]*/fenriz$" >/dev/null; then
+    echo "a nested fenriz is already running — stop it first (pkill -f '$ROOT/build/.*/fenriz')"; exit 1
+fi
+
+export WLR_BACKENDS=wayland WLR_WL_OUTPUTS=2 FENRIZ_LOG=$LOG
+export ASAN_OPTIONS="detect_leaks=1:halt_on_error=0:abort_on_error=0:detect_stack_use_after_return=1"
+export LSAN_OPTIONS="suppressions=$ROOT/scripts/lsan-suppressions.txt:print_suppressions=0"
+export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0"
+
+case $MODE in
+    valgrind)  LAUNCH=(valgrind --leak-check=full --show-leak-kinds=definite,indirect
+                       --track-origins=yes --error-limit=no --log-file="$OUT/valgrind.txt" "$BIN") ;;
+    # --record-only or heaptrack pops its GUI open on the user's live session when the
+    # trace finishes, and the wrapper then never exits. Analyze with heaptrack_print.
+    heaptrack) LAUNCH=(heaptrack --record-only -o "$OUT/heaptrack" "$BIN") ;;
+    *)         LAUNCH=("$BIN") ;;
+esac
+
+echo "mode=$MODE cycles=$CYCLES out=$OUT"
+"${LAUNCH[@]}" >"$OUT/stdout.txt" 2>"$OUT/stderr.txt" &
+LAUNCH_PID=$!
+
+# The compositor's own log is the only trustworthy source for its socket path.
+# Startup under valgrind is ~50x slower (GL/EGL init dominates), so wait much longer there.
+SOCK=""
+WAIT=60
+[ "$MODE" = valgrind ] && WAIT=600
+for _ in $(seq $WAIT); do
+    [ -s "$LOG" ] && SOCK=$(grep -o 'FENRIZ_SOCKET=[^ ]*' "$LOG" | tail -1 | cut -d= -f2)
+    [ -n "$SOCK" ] && [ -S "$SOCK" ] && break
+    sleep 0.5
+done
+[ -n "$SOCK" ] || { echo "nested fenriz never came up; see $OUT/stderr.txt"; kill $LAUNCH_PID 2>/dev/null; exit 1; }
+NESTED_DISPLAY=$(grep -o 'WAYLAND_DISPLAY=[^ ]*' "$LOG" | tail -1 | cut -d= -f2)
+FENRIZ_PID=$(pgrep -f "^${BIN}$" | head -1)
+[ -n "$FENRIZ_PID" ] || FENRIZ_PID=$LAUNCH_PID
+echo "nested display=$NESTED_DISPLAY sock=$SOCK pid=$FENRIZ_PID"
+
+ipc() { printf '%s\n' "$1" | timeout 2 socat -T1 - "UNIX-CONNECT:$SOCK" >/dev/null 2>&1; }
+rss() { awk '/^VmRSS:/{print $2}' "/proc/$FENRIZ_PID/status" 2>/dev/null || echo 0; }
+
+# A couple of real clients so map/unmap, popups and the tiling tree are actually exercised.
+spawn_clients() {
+    for _ in 1 2; do
+        WAYLAND_DISPLAY=$NESTED_DISPLAY foot >/dev/null 2>&1 &
+    done 2>/dev/null
+    command -v foot >/dev/null || WAYLAND_DISPLAY=$NESTED_DISPLAY weston-terminal >/dev/null 2>&1 &
+    sleep 1
+}
+
+spawn_clients
+sleep 2
+BASE=$(rss)
+echo "baseline RSS: ${BASE} kB"
+
+for i in $(seq "$CYCLES"); do
+    ipc '{"cmd":"workspace","n":2}'
+    ipc '{"cmd":"workspace","n":1}'
+    # zoom in/out: the offscreen swapchain path (F1)
+    ipc '{"cmd":"dispatch","action":"fullscreen"}'
+    ipc '{"cmd":"dispatch","action":"fullscreen"}'
+    # output churn: scene outputs, layer surfaces, workspace evacuation/restore
+    ipc '{"cmd":"output","name":"WL-2","enabled":false}'
+    ipc '{"cmd":"output","name":"WL-2","enabled":true}'
+    # lid policy, same funnel from a different entry point
+    ipc '{"cmd":"lid","closed":true}'
+    ipc '{"cmd":"lid","closed":false}'
+    # config reload: rebuilds every Bind/WindowRule/OutputCfg and re-places every view
+    ipc '{"cmd":"reload"}'
+    # float/tile transitions move views in and out of the BSP tree
+    ipc '{"cmd":"dispatch","action":"togglefloating"}'
+    ipc '{"cmd":"dispatch","action":"togglefloating"}'
+    sleep 0.4
+    printf 'cycle %2d/%s  RSS %s kB\n' "$i" "$CYCLES" "$(rss)"
+done
+
+sleep 2
+END=$(rss)
+echo "---"
+echo "RSS: ${BASE} -> ${END} kB (delta $((END - BASE)) kB over $CYCLES cycles)"
+
+ipc '{"cmd":"exit"}'
+wait $LAUNCH_PID 2>/dev/null
+
+case $MODE in
+    sanitize)
+        echo "--- sanitizer report ---"
+        grep -E "ERROR: (Address|Leak)Sanitizer|runtime error|SUMMARY" "$OUT/stderr.txt" || echo "clean"
+        ;;
+    valgrind)  echo "--- valgrind ---"; grep -E "definitely lost|indirectly lost|ERROR SUMMARY" "$OUT/valgrind.txt" ;;
+    heaptrack)
+        echo "--- heaptrack: leaked at exit (top 10 by size) ---"
+        heaptrack_print --print-leaks 1 --print-flamegraph "" "$OUT"/heaptrack.zst 2>/dev/null \
+            | sed -n '/LEAKED ALLOCATIONS/,/^$/p' | head -60
+        echo "(full profile: heaptrack_gui $OUT/heaptrack.zst)"
+        ;;
+esac
+echo "artifacts in $OUT"

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -30,7 +30,8 @@ namespace fenriz::ipc {
         struct IpcState {
             Server* server = nullptr;
             wl_event_loop* loop = nullptr;
-            int listen_fd = -1;
+            wl_event_source* listen_src = nullptr;
+            std::string path;
             std::vector<Client> clients;
             std::string last;             // last broadcast snapshot; skip re-sending if unchanged
             bool publish_pending = false; // an idle broadcast is already queued this iteration
@@ -350,8 +351,15 @@ namespace fenriz::ipc {
         g = new IpcState{};
         g->server = &server;
         g->loop = wl_display_get_event_loop(server.display);
-        g->listen_fd = fd;
-        wl_event_loop_add_fd(g->loop, fd, WL_EVENT_READABLE, on_listen_readable, g);
+        g->path = path;
+        g->listen_src = wl_event_loop_add_fd(g->loop, fd, WL_EVENT_READABLE, on_listen_readable, g);
+        if (!g->listen_src) {
+            close(fd);
+            delete g;
+            g = nullptr;
+            wlr_log(WLR_ERROR, "fenriz ipc: could not register the listen socket");
+            return;
+        }
 
         setenv("FENRIZ_SOCKET", path.c_str(), true);
         wlr_log(WLR_INFO, "fenriz ipc: listening on FENRIZ_SOCKET=%s", path.c_str());
@@ -390,6 +398,18 @@ namespace fenriz::ipc {
             return;
         g->publish_pending = true;
         wl_event_loop_add_idle(g->loop, publish_idle, nullptr);
+    }
+
+    void shutdown() {
+        if (!g)
+            return;
+        for (const Client& c : g->clients)
+            wl_event_source_remove(c.src);
+        wl_event_source_remove(g->listen_src);
+        if (!g->path.empty())
+            unlink(g->path.c_str());
+        delete g;
+        g = nullptr;
     }
 
 } // namespace fenriz::ipc

--- a/src/ipc.hpp
+++ b/src/ipc.hpp
@@ -17,6 +17,9 @@ namespace fenriz {
         // switch, view map/unmap/destroy).
         void publish(Server& server);
 
+        // Close the control socket, drop every connected client, and remove the socket file.
+        void shutdown();
+
     } // namespace ipc
 
 } // namespace fenriz

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -193,9 +193,8 @@ namespace fenriz::output {
             // zoom is active/animating/just-ended here. An idle, unchanged output commits nothing.
             if (wlr_scene_output_needs_frame(so) || output->gamma_dirty || zoomed || zoom_animating || exiting_zoom) {
                 // (Re)apply SceneFX per-window effects right before rendering. scenefx re-syncs
-                // each surface buffer during its own commit handling (after our commit handler),
-                // resetting opacity to 1.0 — so effects set at commit time never reach the
-                // render. Applying here, per visible view, is the reliable point.
+                // each surface buffer during its own commit handling (after our commit handler), resetting opacity
+                // to 1.0
                 for (View* view : server.views)
                     if (view_visible(server, view) && view_output(server, view) == output)
                         apply_view_effects(view);
@@ -203,8 +202,13 @@ namespace fenriz::output {
                 if (zoomed) {
                     render_zoomed(output, so, &now);
                 } else {
-                    if (exiting_zoom)
+                    if (exiting_zoom) {
                         wlr_damage_ring_add_whole(&so->damage_ring); // propagates to every buffer via rotate
+                        if (output->zoom_swapchain) {
+                            wlr_swapchain_destroy(output->zoom_swapchain);
+                            output->zoom_swapchain = nullptr;
+                        }
+                    }
                     wlr_output_state state;
                     wlr_output_state_init(&state);
                     wlr_scene_output_build_state(so, &state, nullptr);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -37,6 +37,7 @@ namespace fenriz {
             wl_listener commit;
             wl_listener destroy;
             wl_listener reposition;
+            wl_listener tree_destroy;
         };
 
         // Walk up through nested submenus to the xdg surface a popup chain hangs off.
@@ -126,12 +127,23 @@ namespace fenriz {
             wlr_xdg_surface_schedule_configure(p->popup->base);
         }
 
+        // The popup's scene tree was freed. base->data still points at it, and wlroots never
+        // invalidates that field, so null it here.
+        void on_popup_tree_destroy(wl_listener* listener, void* data) {
+            Popup* p = wl_container_of(listener, p, tree_destroy);
+            (void)data;
+            p->popup->base->data = nullptr;
+            wl_list_remove(&p->tree_destroy.link);
+            wl_list_init(&p->tree_destroy.link); // on_popup_destroy removes it again
+        }
+
         void on_popup_destroy(wl_listener* listener, void* data) {
             Popup* p = wl_container_of(listener, p, destroy);
             (void)data;
             wl_list_remove(&p->commit.link);
             wl_list_remove(&p->destroy.link);
             wl_list_remove(&p->reposition.link);
+            wl_list_remove(&p->tree_destroy.link);
             delete p;
         }
 
@@ -146,8 +158,6 @@ namespace fenriz {
             wlr_xdg_surface* parent = wlr_xdg_surface_try_from_wlr_surface(popup->parent);
             if (!parent || !parent->data)
                 return;
-            // parent->data holds a raw scene tree wlroots never invalidates. If the owning
-            // toplevel has unmapped, view_handle_unmap freed its whole scene subtree
             wlr_xdg_surface* root = popup_root(parent);
             if (!root)
                 return; // non-xdg (layer-shell) root: not placed here
@@ -193,15 +203,18 @@ namespace fenriz {
             if (path.empty())
                 return;
             std::string dir = path.substr(0, path.find_last_of('/'));
-            server.inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
-            if (server.inotify_fd < 0)
+            int fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+            if (fd < 0)
                 return;
-            if (inotify_add_watch(server.inotify_fd, dir.c_str(), IN_CLOSE_WRITE | IN_MOVED_TO) < 0) {
-                close(server.inotify_fd);
-                server.inotify_fd = -1;
+            if (inotify_add_watch(fd, dir.c_str(), IN_CLOSE_WRITE | IN_MOVED_TO) < 0) {
+                close(fd);
                 return;
             }
-            wl_event_loop_add_fd(loop, server.inotify_fd, WL_EVENT_READABLE, on_config_changed, &server);
+            server.config_watch = wl_event_loop_add_fd(loop, fd, WL_EVENT_READABLE, on_config_changed, &server);
+            if (!server.config_watch) {
+                close(fd);
+                return;
+            }
             wlr_log(WLR_INFO, "fenriz: watching %s for changes", path.c_str());
         }
 
@@ -221,8 +234,9 @@ namespace fenriz {
 
         void on_drag_icon_destroy(wl_listener* listener, void*) {
             SignalListener* sl = wl_container_of(listener, sl, listener);
-            sl->server->drag_icon = nullptr;    // scene node is freed by wlroots; just drop our handle
-            wl_list_remove(&sl->listener.link); // re-arm for the next drag
+            sl->server->drag_icon = nullptr; // scene node is freed by wlroots
+            wl_list_remove(&sl->listener.link);
+            wl_list_init(&sl->listener.link);
         }
 
         void on_request_start_drag(wl_listener* listener, void* data) {
@@ -239,7 +253,14 @@ namespace fenriz {
             // (process_motion) track it. wlroots frees the node when the icon is destroyed.
             if (ev->drag->icon) {
                 Server* s = sl->server;
-                s->drag_icon = wlr_scene_drag_icon_create(s->scene_overlay, ev->drag->icon);
+                if (s->drag_icon) {
+                    wl_list_remove(&s->l_drag_icon_destroy.listener.link);
+                    s->drag_icon = nullptr;
+                }
+                wlr_scene_tree* icon = wlr_scene_drag_icon_create(s->scene_overlay, ev->drag->icon);
+                if (!icon)
+                    return; // nothing to render or track
+                s->drag_icon = icon;
                 s->l_drag_icon_destroy.server = s;
                 add_listener(s->l_drag_icon_destroy.listener, ev->drag->icon->events.destroy, on_drag_icon_destroy);
             }
@@ -347,11 +368,16 @@ namespace fenriz {
     // Parent a popup into `parent_tree` so it renders above its parent and tracks its
     // position, and take responsibility for configuring it.
     void popup_create(Server& server, wlr_xdg_popup* popup, wlr_scene_tree* parent_tree) {
-        popup->base->data = wlr_scene_xdg_surface_create(parent_tree, popup->base);
-        Popup* p = new Popup{&server, popup, {}, {}, {}};
+        wlr_scene_tree* tree = wlr_scene_xdg_surface_create(parent_tree, popup->base);
+        popup->base->data = tree;
+        Popup* p = new Popup{&server, popup, {}, {}, {}, {}};
         add_listener(p->commit, popup->base->surface->events.commit, on_popup_commit);
         add_listener(p->destroy, popup->events.destroy, on_popup_destroy);
         add_listener(p->reposition, popup->events.reposition, on_popup_reposition);
+        if (tree)
+            add_listener(p->tree_destroy, tree->node.events.destroy, on_popup_tree_destroy);
+        else
+            wl_list_init(&p->tree_destroy.link); // on_popup_destroy removes it unconditionally
     }
 
     void spawn(const std::string& cmd) {
@@ -377,16 +403,12 @@ namespace fenriz {
     Server::Server() { config = Config::load(); }
 
     Server::~Server() {
-        if (inotify_fd >= 0)
-            close(inotify_fd);
+        if (config_watch)
+            wl_event_source_remove(config_watch);
+        ipc::shutdown();
         if (display) {
-            // Disconnect clients politely, then stop. We deliberately don't
-            // wl_display_destroy(): wlroots' globals assert on teardown that nobody is still
-            // subscribed to their signals.
             wl_display_destroy_clients(display);
         }
-        // ponytail: backend/renderer/allocator leak at process exit — add explicit
-        // teardown (wlr_backend_destroy etc.) if fenriz ever restarts in-process.
     }
 
     bool Server::start() {

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -136,7 +136,8 @@ namespace fenriz {
         // The workspaces (see Workspace above). Tree nodes leak at shutdown.
         Workspace workspaces[WS_COUNT];
 
-        int inotify_fd = -1; // watches the config dir for hot-reload; closed in ~Server
+        // Watches the config dir for hot-reload.
+        wl_event_source* config_watch = nullptr;
 
         // Held-key repeat for `binde` binds. One timer for the seat.
         wl_event_source* repeat_timer = nullptr;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1,6 +1,7 @@
 #include "view.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -366,9 +367,18 @@ namespace fenriz {
             set_fullscreen(*view->server, view, want);
         }
 
+        // wlroots unmaps a surface before destroying its role object, so `mapped` should always
+        // be false here.
+        void view_force_unmap(View* view) {
+            assert(!view->mapped && "view destroyed while still mapped");
+            if (view->mapped)
+                view_handle_unmap(&view->unmap, nullptr);
+        }
+
         void view_handle_destroy(wl_listener* listener, void* data) {
             View* view = wl_container_of(listener, view, destroy);
             (void)data;
+            view_force_unmap(view);
             wl_list_remove(&view->map.link);
             wl_list_remove(&view->unmap.link);
             wl_list_remove(&view->commit.link);
@@ -427,6 +437,7 @@ namespace fenriz {
         void view_xwl_handle_destroy(wl_listener* listener, void* data) {
             View* view = wl_container_of(listener, view, destroy);
             (void)data;
+            view_force_unmap(view);
             // map/unmap/commit were already removed at dissociate (wlroots dissociates before
             // destroy); remove only the surface-independent links wired in the ctor.
             wl_list_remove(&view->destroy.link);
@@ -883,6 +894,15 @@ namespace fenriz {
         place_view_nodes(view);
     }
 
+    // Unreference the gradient texture from this view's edge bands.
+    static void release_gradient(View* view) {
+        if (view->grad_gen == 0)
+            return;
+        for (wlr_scene_buffer* edge : view->grad_edge)
+            wlr_scene_buffer_set_buffer(edge, nullptr);
+        view->grad_gen = 0;
+    }
+
     // has the client answered the last size we asked it for
     static bool view_settled(const View* view) {
         if (view->kind == View::Kind::Xdg)
@@ -897,8 +917,10 @@ namespace fenriz {
         view->frame = view->box; // never leave it zeroed; the real value is computed below
         const bool vis = view_visible(server, view);
         wlr_scene_node_set_enabled(&view->scene_tree->node, vis);
-        if (!vis)
+        if (!vis) {
+            release_gradient(view);
             return;
+        }
 
         const int bw = view->fullscreen ? 0 : server.config.border_width;
 
@@ -1011,8 +1033,7 @@ namespace fenriz {
             const bool reupload = view->grad_gen != gen;
             for (int i = 0; i < 4; i++) {
                 wlr_scene_buffer* n = view->grad_edge[i];
-                if (band[i].width <= 0 || band[i].height <= 0)
-                    continue;
+                // Re-upload every band, including currently-empty ones.
                 if (reupload) {
                     // HACK: the node caches the built texture and handing it a different buffer does
                     // not invalidate that cache. removing the nullptr makes the bands keep drawing the
@@ -1020,12 +1041,16 @@ namespace fenriz {
                     wlr_scene_buffer_set_buffer(n, nullptr);
                     wlr_scene_buffer_set_buffer(n, tex);
                 }
+                if (band[i].width <= 0 || band[i].height <= 0)
+                    continue;
                 wlr_scene_node_set_position(&n->node, band[i].x, band[i].y);
                 wlr_scene_buffer_set_dest_size(n, band[i].width, band[i].height);
                 const wlr_fbox src = grad_src(band[i].x, band[i].y, band[i].width, band[i].height, W, H);
                 wlr_scene_buffer_set_source_box(n, &src);
             }
             view->grad_gen = gen;
+        } else {
+            release_gradient(view); // gradient off, or this view lost focus
         }
 
         // glow

--- a/src/xwayland.cpp
+++ b/src/xwayland.cpp
@@ -95,7 +95,10 @@ namespace fenriz::xwayland {
 
         void unmanaged_destroy(wl_listener* listener, void* data) {
             Unmanaged* u = wl_container_of(listener, u, destroy);
-            (void)data;
+            if (u->surface_tree) {
+                wlr_scene_node_destroy(&u->surface_tree->node);
+                u->surface_tree = nullptr;
+            }
             // map/unmap already removed at dissociate; drop the surface-independent links.
             wl_list_remove(&u->associate.link);
             wl_list_remove(&u->dissociate.link);


### PR DESCRIPTION
- fix: release the zoom offscreen swapchain when zoom exits instead of pinning it (~100MB on 4K) for the session
- fix: null a popup's stale xdg_surface->data when its scene tree is freed, so a remapped toplevel can't parent a popup into freed memory
- fix: drop the gradient border texture when a view is hidden or its gradient is off, instead of holding the buffer lock forever
- fix: re-upload all four gradient bands before marking grad_gen current, so a zero-size band doesn't later draw a stale generation
- fix: re-init the drag-icon listener link and guard the re-add, so a second drag can't corrupt the previous icon's signal list
- fix: run the unmap teardown if a View or unmanaged X surface is destroyed while still mapped, instead of leaving dangling pointers in views/tree/focus/cursor
- fix: remove the inotify config-watch event source in ~Server (it owns the fd; the old close() would double-close)
- fix: close the IPC control socket, drop connected clients, and unlink the socket file on shutdown
- chore: add sanitize CMake preset, LSan suppressions, and scripts/mem-stress.sh
