### PR TITLE
fix: brighter poppier gradient border

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -117,12 +117,13 @@ Colors are `0xRRGGBBAA` hex.
 | Key | Default | Meaning |
 |---|---|---|
 | `border_width` | `2` | border thickness, px |
-| `border_active` | `0x33ccffff` | focused window border |
-| `border_inactive` | `0x444444ff` | unfocused window border |
+| `border_active` | `0x16b8f3cc` | focused window border |
+| `border_inactive` | `0x44444488` | unfocused window border |
 | `border_gradient` | unset | focused border fades from `border_active` (top-left) to this (bottom-right) at 45°; unset = flat |
+| `border_gradient_ease` | `1.0` | how long the ramp holds its endpoint colors. `0` = straight linear sweep, `1` = smoothstep |
 | `shadow` | `on` | soft glow behind the focused window |
-| `shadow_color` | `0x33ccff66` | glow color (low alpha = subtle) |
-| `shadow_blur` | `18` | glow spread, px |
+| `shadow_color` | `0x00000055` | glow intensity: only the alpha is used |
+| `shadow_blur` | `28` | glow spread, px |
 | `gaps` | `8` | gap between windows, px |
 | `rounding` | `10` | corner radius, px |
 | `animation` | `150` | slide-into-place duration, ms; `0` = off |

--- a/fenriz.conf.example
+++ b/fenriz.conf.example
@@ -2,17 +2,17 @@
 
 # settings: key = value
 border_width     = 2
-border_active    = 0x16b8f3cc   # RGBA hex; translucent alpha softens the edge
-border_inactive  = 0x44444488   # dim so unfocused borders nearly vanish
+border_active    = 0x16b8f3CC    # RGBA hex; translucent alpha softens the edge
+border_inactive  = 0x44444488    # dim so unfocused borders nearly vanish
 shadow           = on            # soft glow behind the focused window
 shadow_color     = 0x00000055    # RGBA hex; alpha = glow intensity, hue tracks border_active
 shadow_blur      = 28            # glow spread in px; wider = softer
-# border_gradient  = 0xff2090ff  # RGBA hex, Optional; focused border fades border_active (top-left) to this (bottom-right), 45°.
+border_gradient  =0xff2090ff     # RGBA hex, Optional; focused border fades border_active (top-left) to this (bottom-right), 45°.
 # border_gradient_ease = 1.0     # 0.0 = straight linear sweep, 1.0 = smoothstep
 gaps             = 8
-rounding         = 10           # corner radius in px
-animation        = 150          # window slide-into-place, ms; 0 = instant (off)
-opacity          = 0.95         # 0.0..1.0
+rounding         = 10            # corner radius in px
+animation        = 150           # window slide-into-place, ms; 0 = instant (off)
+opacity          = 0.95          # 0.0..1.0
 scale            = auto          # auto = guess each screen's scale from its DPI (1x/1.5x/2x).
                                  # A number here forces every screen to it; the per-output
                                  # `output = ...` scale below overrides either.

--- a/fenriz.conf.example
+++ b/fenriz.conf.example
@@ -8,6 +8,7 @@ shadow           = on            # soft glow behind the focused window
 shadow_color     = 0x00000055    # RGBA hex; alpha = glow intensity, hue tracks border_active
 shadow_blur      = 28            # glow spread in px; wider = softer
 # border_gradient  = 0xff2090ff  # RGBA hex, Optional; focused border fades border_active (top-left) to this (bottom-right), 45°.
+# border_gradient_ease = 1.0     # 0.0 = straight linear sweep, 1.0 = smoothstep
 gaps             = 8
 rounding         = 10           # corner radius in px
 animation        = 150          # window slide-into-place, ms; 0 = instant (off)

--- a/src/color.hpp
+++ b/src/color.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace fenriz {
+
+    // sRGB transfer function (IEC 61966-2-1).
+    inline float srgb_to_linear(uint32_t b) {
+        const float c = b / 255.0f;
+        return c <= 0.04045f ? c / 12.92f : std::pow((c + 0.055f) / 1.055f, 2.4f);
+    }
+
+    inline uint32_t linear_to_srgb(float v) {
+        v = std::clamp(v, 0.0f, 1.0f);
+        const float s = v <= 0.0031308f ? v * 12.92f : 1.055f * std::pow(v, 1.0f / 2.4f) - 0.055f;
+        return (uint32_t)(s * 255.0f + 0.5f);
+    }
+
+    // Blend two 0xRRGGBBAA colors, t in [0,1]. RGB mixes in linear light
+    inline uint32_t u32_lerp(uint32_t a, uint32_t b, float t) {
+        const float aa = (float)(a & 0xff), ab = (float)(b & 0xff);
+        uint32_t out = (uint32_t)(aa + (ab - aa) * t + 0.5f) & 0xff;
+        for (int shift = 8; shift < 32; shift += 8) {
+            const float la = srgb_to_linear((a >> shift) & 0xff);
+            const float lb = srgb_to_linear((b >> shift) & 0xff);
+            out |= linear_to_srgb(la + (lb - la) * t) << shift;
+        }
+        return out;
+    }
+
+    inline uint32_t u32_mix(uint32_t a, uint32_t b) { return u32_lerp(a, b, 0.5f); }
+
+    // gradient ramp so it lingers near its endpoints.
+    inline float ramp_ease(float t, float amount) { return t + amount * ((3.0f - 2.0f * t) * t * t - t); }
+
+} // namespace fenriz

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -282,6 +282,8 @@ namespace fenriz {
                 cfg.border_inactive = parse_color(val, cfg.border_inactive);
             else if (key == "border_gradient")
                 cfg.border_gradient = parse_color(val, cfg.border_gradient);
+            else if (key == "border_gradient_ease")
+                cfg.border_gradient_ease = parse_float(val, cfg.border_gradient_ease, 0.0f, 1.0f);
             else if (key == "shadow")
                 cfg.shadow = parse_bool(val, cfg.shadow);
             else if (key == "shadow_color")

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -60,6 +60,7 @@ namespace fenriz {
         uint32_t border_active = 0x16b8f3cc;   // RGBA — translucent so the edge isn't a hard stroke
         uint32_t border_inactive = 0x44444488; // RGBA — dim; unfocused borders nearly vanish
         uint32_t border_gradient = 0;          // RGBA — second accent washed across the focused border; 0 = flat
+        float border_gradient_ease = 1.0f;     // 0 = linear sweep, 1 = smoothstep
         bool shadow = true;                    // soft glow behind the focused window
         uint32_t shadow_color = 0x00000055;    // RGBA — alpha = glow intensity; hue tracks border_active
         int shadow_blur = 28;                  // blur sigma (px) — wider halo = softer falloff

--- a/src/test_config.cpp
+++ b/src/test_config.cpp
@@ -1,3 +1,4 @@
+#include "color.hpp"
 #include "config.hpp"
 
 #include <cassert>
@@ -46,6 +47,23 @@ int main() {
 
     // unset leaves the border flat
     assert(Config::parse("").border_gradient == 0u);
+
+    assert(u32_mix(0x16b8f3ffu, 0x16b8f3ffu) == 0x16b8f3ffu);    // identity
+    assert(u32_mix(0x000000ffu, 0xffffffffu) == 0xbcbcbcffu);    // linear grey, not 0x80
+    assert(u32_mix(0x16b8f3ffu, 0xff2090ffu) == 0xbc88caffu);    // zima blue -> magenta
+    assert((u32_mix(0x16b8f300u, 0x16b8f3ffu) & 0xff) == 0x80u); // alpha averages directly, rounded
+
+    assert(u32_lerp(0x16b8f3ffu, 0xff2090ffu, 0.0f) == 0x16b8f3ffu);
+    assert(u32_lerp(0x16b8f3ffu, 0xff2090ffu, 1.0f) == 0xff2090ffu);
+
+    assert(ramp_ease(0.5f, 1.0f) == 0.5f);
+    assert(ramp_ease(0.0f, 1.0f) == 0.0f && ramp_ease(1.0f, 1.0f) == 1.0f);
+    assert(ramp_ease(0.25f, 0.0f) == 0.25f); // amount 0 = linear passthrough
+    assert(ramp_ease(0.25f, 1.0f) < 0.25f);  // pulled toward the low endpoint
+    assert(ramp_ease(0.75f, 1.0f) > 0.75f);  // pulled toward the high endpoint
+    assert(Config{}.border_gradient_ease == 1.0f);
+    assert(Config::parse("border_gradient_ease = 0.4\n").border_gradient_ease > 0.39f);
+    assert(Config::parse("border_gradient_ease = 9\n").border_gradient_ease == 1.0f); // clamped
 
     // exec-once keeps the full command (not comma-split like binds).
     assert(c.exec_once.size() == 1);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 
+#include "color.hpp"
 #include "cursor.hpp"
 #include "ipc.hpp"
 #include "server.hpp"
@@ -28,19 +29,12 @@ namespace fenriz {
             out[3] = a;
         }
 
-        // halfway between two 0xRRGGBBAA colors per channel
-        uint32_t u32_mix(uint32_t a, uint32_t b) {
-            uint32_t out = 0;
-            for (int shift = 0; shift < 32; shift += 8) {
-                const uint32_t ca = (a >> shift) & 0xff, cb = (b >> shift) & 0xff;
-                out |= ((ca + cb) / 2) << shift;
-            }
-            return out;
-        }
+        // ramp resolution
+        constexpr int GRAD_N = 17;
 
         struct GradBuffer {
             wlr_buffer base;
-            uint32_t px[4]; // premultiplied ARGB8888, row-major: TL, TR, BL, BR
+            uint32_t px[GRAD_N * GRAD_N]; // premultiplied ARGB8888, row-major
         };
 
         void grad_buffer_destroy(wlr_buffer* buffer) {
@@ -54,7 +48,7 @@ namespace fenriz {
             GradBuffer* g = wl_container_of(buffer, g, base);
             *data = g->px;
             *format = DRM_FORMAT_ARGB8888;
-            *stride = 2 * sizeof(uint32_t);
+            *stride = GRAD_N * sizeof(uint32_t);
             return true;
         }
 
@@ -80,19 +74,23 @@ namespace fenriz {
         wlr_buffer* gradient_texture(const Config& cfg, uint32_t* gen) {
             static wlr_buffer* cached = nullptr;
             static uint32_t cached_from = 0, cached_to = 0, generation = 0;
+            static float cached_ease = -1.0f;
 
-            if (cached && cached_from == cfg.border_active && cached_to == cfg.border_gradient) {
+            if (cached && cached_from == cfg.border_active && cached_to == cfg.border_gradient &&
+                cached_ease == cfg.border_gradient_ease) {
                 *gen = generation;
                 return cached;
             }
 
             GradBuffer* g = new GradBuffer{};
-            wlr_buffer_init(&g->base, &grad_buffer_impl, 2, 2);
-            const uint32_t mid = u32_mix(cfg.border_active, cfg.border_gradient);
-            g->px[0] = premul_argb(cfg.border_active);
-            g->px[1] = premul_argb(mid);
-            g->px[2] = premul_argb(mid);
-            g->px[3] = premul_argb(cfg.border_gradient);
+            wlr_buffer_init(&g->base, &grad_buffer_impl, GRAD_N, GRAD_N);
+            for (int j = 0; j < GRAD_N; j++) {
+                for (int i = 0; i < GRAD_N; i++) {
+                    const float t = (float)(i + j) / (2 * (GRAD_N - 1));
+                    const float e = ramp_ease(t, cfg.border_gradient_ease);
+                    g->px[j * GRAD_N + i] = premul_argb(u32_lerp(cfg.border_active, cfg.border_gradient, e));
+                }
+            }
 
             if (cached)
                 wlr_buffer_drop(cached); // live nodes keep their lock until they re-set
@@ -100,16 +98,19 @@ namespace fenriz {
             cached = &g->base;
             cached_from = cfg.border_active;
             cached_to = cfg.border_gradient;
+            cached_ease = cfg.border_gradient_ease;
             *gen = ++generation;
             return cached;
         }
 
+        // Map a band's window-space rect into the ramp texture
         wlr_fbox grad_src(int x, int y, int w, int h, int fw, int fh) {
+            constexpr double s = GRAD_N - 1;
             return {
-                .x = 0.5 + (double)x / fw,
-                .y = 0.5 + (double)y / fh,
-                .width = (double)w / fw,
-                .height = (double)h / fh,
+                .x = 0.5 + s * x / fw,
+                .y = 0.5 + s * y / fh,
+                .width = s * w / fw,
+                .height = s * h / fh,
             };
         }
 
@@ -1057,10 +1058,14 @@ namespace fenriz {
         const bool glow = server.config.shadow && !view->fullscreen && view == server.focused_view;
         wlr_scene_node_set_enabled(&view->shadow->node, glow);
         if (glow) {
+            const uint32_t glow_rgba = server.config.border_gradient
+                                           ? u32_mix(server.config.border_active, server.config.border_gradient)
+                                           : server.config.border_active;
             float scol[4];
-            u32_color(server.config.border_active, scol);
+            u32_color(glow_rgba, scol);
             scol[3] = (server.config.shadow_color & 0xff) / 255.0f;
             wlr_scene_shadow_set_color(view->shadow, scol);
+            wlr_scene_shadow_set_blur_sigma(view->shadow, (float)server.config.shadow_blur);
             wlr_scene_shadow_set_size(view->shadow, box.width, box.height);
             wlr_scene_shadow_set_corner_radius(view->shadow, server.config.rounding);
             wlr_scene_shadow_set_clipped_region(view->shadow, hole);


### PR DESCRIPTION
The focused border's gradient was dull in the middle and its endpoint colors barely visible. Two causes, both fixed.