### PR TITLE
fix: floating dialogs render too big. [desktop] feat: pam auth modules (face, fingerprint)

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(fenriz-desktop
     src/menu.cpp
     src/launcher.cpp
     src/frecency.cpp
+    src/search.cpp
     src/spawn.cpp
     src/auth.cpp
     src/lock.cpp
@@ -82,6 +83,11 @@ target_include_directories(desktop_frecency_test PRIVATE ${CMAKE_CURRENT_SOURCE_
 target_link_libraries(desktop_frecency_test PRIVATE PkgConfig::GTK4)
 target_compile_options(desktop_frecency_test PRIVATE -UNDEBUG)
 
+add_executable(desktop_search_test src/search.cpp src/test_search.cpp)
+target_include_directories(desktop_search_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(desktop_search_test PRIVATE PkgConfig::GIO_UNIX)
+target_compile_options(desktop_search_test PRIVATE -UNDEBUG)
+
 add_executable(desktop_auth_test src/auth.cpp src/test_auth.cpp)
 target_include_directories(desktop_auth_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(desktop_auth_test PRIVATE PkgConfig::GTK4 pam)
@@ -106,6 +112,7 @@ enable_testing()
 add_test(NAME config   COMMAND desktop_config_test)
 add_test(NAME menu     COMMAND desktop_menu_test)
 add_test(NAME frecency COMMAND desktop_frecency_test)
+add_test(NAME search   COMMAND desktop_search_test)
 add_test(NAME auth     COMMAND desktop_auth_test)
 add_test(NAME brightness COMMAND desktop_brightness_test)
 add_test(NAME wallpaper COMMAND desktop_wallpaper_test)

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -66,7 +66,7 @@ install(FILES fenriz-desktop.conf.example
 ### IMPORTANT ###
 # Not installed into /etc/pam.d automatically: a PAM file is a security surface and its
 # contents are distro-specific. Packagers and users copy it deliberately.
-install(FILES pam/fenriz-desktop
+install(FILES pam/fenriz-desktop pam/fenriz-desktop-fprint pam/fenriz-desktop-gaze
         DESTINATION ${CMAKE_INSTALL_DATADIR}/fenriz-desktop/pam)
 
 add_executable(desktop_config_test src/config.cpp src/test_config.cpp)

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -138,10 +138,16 @@ If you do get stuck behind a lock screen, switch to a TTY and force-unlock
 fenrizctl unlock                          # finds the socket on its own
 ```
 
-Fingerprint and face are not wired up yet. They cannot share this PAM stack:
-PAM is serial, so "fingerprint OR face OR password, whichever answers first"
-needs one single-module service per method, raced, first success winning.
-`Authenticator::begin_passive()` is the seam they attach to.
+### Fingerprint and face
+
+Both are optional and both are off until you install their service file. They only start if the service file is present.
+
+```sh
+sudo install -m644 /usr/share/fenriz-desktop/pam/fenriz-desktop-fprint /etc/pam.d/   # pam_fprintd.so
+sudo install -m644 /usr/share/fenriz-desktop/pam/fenriz-desktop-gaze   /etc/pam.d/   # pam_gaze.so
+```
+
+Enroll first: `fprintd-enroll` for the reader, `gaze` for the camera.
 
 ## Polkit agent
 

--- a/desktop/pam/fenriz-desktop-fprint
+++ b/desktop/pam/fenriz-desktop-fprint
@@ -1,0 +1,13 @@
+# Fingerprint for fenriz-desktop's lock screen.
+# Install to /etc/pam.d/fenriz-desktop-fprint. Requires fprintd and an enrolled
+# finger (`fprintd-enroll`). Not installing this file disables fingerprint: the
+# lock screen only races a method whose service file exists.
+#
+# One module, on purpose. PAM is serial, so racing fingerprint against the
+# password needs its own service — see pam/fenriz-desktop.
+
+auth    required pam_fprintd.so
+
+# Not optional: fenriz-desktop runs pam_acct_mgmt after a successful
+# pam_authenticate, and an empty account stack answers PAM_PERM_DENIED.
+account required pam_unix.so

--- a/desktop/pam/fenriz-desktop-gaze
+++ b/desktop/pam/fenriz-desktop-gaze
@@ -1,0 +1,15 @@
+# Face recognition for fenriz-desktop's lock screen.
+# Install to /etc/pam.d/fenriz-desktop-gaze. Requires gaze and an enrolled face
+# (`gaze`). Not installing this file disables face auth: the lock screen only
+# races a method whose service file exists.
+#
+# One module, on purpose. PAM is serial, so racing face against the password
+# needs its own service — see pam/fenriz-desktop.
+#
+# Swap pam_gaze.so for whichever face module you use (howdy ships pam_howdy.so).
+
+auth    required pam_gaze.so
+
+# Not optional: fenriz-desktop runs pam_acct_mgmt after a successful
+# pam_authenticate, and an empty account stack answers PAM_PERM_DENIED.
+account required pam_unix.so

--- a/desktop/src/auth.cpp
+++ b/desktop/src/auth.cpp
@@ -1,5 +1,6 @@
 #include "auth.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <glib.h>
 #include <security/pam_appl.h>
@@ -19,22 +20,59 @@ namespace fenriz::desktop {
         return false;
     }
 
+    const std::vector<std::string>& passive_services() {
+        static const std::vector<std::string> services = {
+            "fenriz-desktop-fprint", // pam_fprintd.so
+            "fenriz-desktop-gaze",   // pam_gaze.so
+        };
+        return services;
+    }
+
     struct AuthAttempt {
         std::atomic<bool> cancelled{false};
         std::atomic<bool> running{true};
         Authenticator::Callback done;
+        Authenticator::Status status;
         std::string service;
         std::string user;
         std::string password;
+        bool passive = false; // fingerprint or face: no secret to type, failure is not a rejection
         int result = PAM_AUTH_ERR;
         std::string message;
     };
 
     namespace {
 
-        // PAM asks for the secret through this
+        using AttemptPtr = std::shared_ptr<AuthAttempt>;
+
+        struct StatusPost {
+            AttemptPtr attempt;
+            std::string text;
+        };
+
+        // Runs on the GTK main loop.
+        gboolean deliver_status(gpointer data) {
+            std::unique_ptr<StatusPost> post(static_cast<StatusPost*>(data));
+            if (!post->attempt->cancelled && post->attempt->status)
+                post->attempt->status(post->text);
+            return G_SOURCE_REMOVE;
+        }
+
+        void post_status(const AttemptPtr& attempt, const char* text) {
+            if (attempt->status && text && *text)
+                g_idle_add(deliver_status, new StatusPost{attempt, text});
+        }
+
+        void free_replies(pam_response* replies, int n) {
+            for (int i = 0; i < n; i++)
+                free(replies[i].resp);
+            free(replies);
+        }
+
+        // PAM asks for the secret through this, and fprintd talks back through it:
+        // "Place your finger on the reader" is a PAM_TEXT_INFO and nothing else.
         int converse(int n, const pam_message** msgs, pam_response** out, void* appdata) {
-            auto* attempt = static_cast<AuthAttempt*>(appdata);
+            const AttemptPtr& attempt = *static_cast<AttemptPtr*>(appdata);
             if (n <= 0 || !msgs || !out)
                 return PAM_CONV_ERR;
 
@@ -46,17 +84,23 @@ namespace fenriz::desktop {
                 switch (msgs[i]->msg_style) {
                 case PAM_PROMPT_ECHO_OFF:
                 case PAM_PROMPT_ECHO_ON:
+                    if (attempt->passive) {
+                        post_status(attempt, msgs[i]->msg);
+                        free_replies(replies, n);
+                        return PAM_CONV_ERR;
+                    }
                     replies[i].resp = strdup(attempt->password.c_str());
                     if (!replies[i].resp) {
-                        free(replies);
+                        free_replies(replies, n);
                         return PAM_BUF_ERR;
                     }
                     break;
                 case PAM_ERROR_MSG:
                 case PAM_TEXT_INFO:
+                    post_status(attempt, msgs[i]->msg);
                     break; // nothing to answer
                 default:
-                    free(replies);
+                    free_replies(replies, n);
                     return PAM_CONV_ERR;
                 }
             }
@@ -64,8 +108,9 @@ namespace fenriz::desktop {
             return PAM_SUCCESS;
         }
 
-        void run_pam(const std::shared_ptr<AuthAttempt>& attempt) {
-            pam_conv conv = {converse, attempt.get()};
+        void run_pam(const AttemptPtr& attempt) {
+            AttemptPtr self = attempt;
+            pam_conv conv = {converse, &self};
             pam_handle_t* pamh = nullptr;
 
             int rc = pam_start(attempt->service.c_str(), attempt->user.c_str(), &conv, &pamh);
@@ -85,13 +130,33 @@ namespace fenriz::desktop {
 
         // Runs on the GTK main loop. Owns the shared_ptr handed over by the worker thread.
         gboolean deliver(gpointer data) {
-            std::unique_ptr<std::shared_ptr<AuthAttempt>> held(static_cast<std::shared_ptr<AuthAttempt>*>(data));
+            std::unique_ptr<AttemptPtr> held(static_cast<AttemptPtr*>(data));
             AuthAttempt& attempt = **held;
             attempt.running = false;
-            if (!attempt.cancelled && attempt.done)
-                attempt.done(pam_result_unlocks(attempt.result), attempt.message);
+            if (attempt.cancelled)
+                return G_SOURCE_REMOVE;
+
+            const bool ok = pam_result_unlocks(attempt.result);
+            // a passive method saying no is not a rejected login
+            if (!ok && attempt.passive) {
+                if (attempt.status && !attempt.message.empty())
+                    attempt.status(attempt.message);
+                return G_SOURCE_REMOVE;
+            }
+            if (attempt.done)
+                attempt.done(ok, attempt.message);
             return G_SOURCE_REMOVE;
         }
+
+        void start(const AttemptPtr& attempt) {
+            // detached on purpose: pam_authenticate cannot be interrupted
+            std::thread([attempt] {
+                run_pam(attempt);
+                g_idle_add(deliver, new AttemptPtr(attempt));
+            }).detach();
+        }
+
+        std::string current_user() { return g_get_user_name() ? g_get_user_name() : ""; }
 
     } // namespace
 
@@ -105,6 +170,10 @@ namespace fenriz::desktop {
         if (current_)
             current_->cancelled = true;
         current_.reset();
+        for (const AttemptPtr& attempt : passive_)
+            attempt->cancelled = true;
+        // cancelled but still running attempts stay tracked: their device is still claimed.
+        std::erase_if(passive_, [](const AttemptPtr& a) { return !a->running; });
     }
 
     void Authenticator::submit_password(std::string_view password, Callback done) {
@@ -113,20 +182,33 @@ namespace fenriz::desktop {
 
         auto attempt = std::make_shared<AuthAttempt>();
         attempt->service = service_;
-        attempt->user = g_get_user_name() ? g_get_user_name() : "";
+        attempt->user = current_user();
         attempt->password = std::string(password);
         attempt->done = std::move(done);
         current_ = attempt;
-
-        // Detached on purpose: pam_authenticate cannot be interrupted
-        std::thread([attempt] {
-            run_pam(attempt);
-            g_idle_add(deliver, new std::shared_ptr<AuthAttempt>(attempt));
-        }).detach();
+        start(attempt);
     }
 
-    void Authenticator::begin_passive(Callback) {
-        // TODO: fprintd and gaze attach here
+    void Authenticator::begin_passive(Callback done, Status status) {
+        std::erase_if(passive_, [](const AttemptPtr& a) { return !a->running; });
+
+        for (const std::string& service : passive_services()) {
+            // no service file means the method is not set up on this machine
+            if (!pam_service_installed(service))
+                continue;
+            if (std::any_of(
+                    passive_.begin(), passive_.end(), [&](const AttemptPtr& a) { return a->service == service; }))
+                continue;
+
+            auto attempt = std::make_shared<AuthAttempt>();
+            attempt->service = service;
+            attempt->user = current_user();
+            attempt->passive = true;
+            attempt->done = done;
+            attempt->status = status;
+            passive_.push_back(attempt);
+            start(attempt);
+        }
     }
 
 } // namespace fenriz::desktop

--- a/desktop/src/auth.hpp
+++ b/desktop/src/auth.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace fenriz::desktop {
 
@@ -15,11 +16,17 @@ namespace fenriz::desktop {
     // Is a PAM service file installed for `service`?
     bool pam_service_installed(const std::string& service);
 
+    // Services raced against the password: fingerprint, face. One module each, because PAM is serial.
+    const std::vector<std::string>& passive_services();
+
     // PAM authentication for the lock screen and the polkit agent.
     class Authenticator {
     public:
         // ok=false message=human-readable reason
         using Callback = std::function<void(bool ok, std::string message)>;
+
+        // PAM message
+        using Status = std::function<void(std::string message)>;
 
         explicit Authenticator(std::string service = "fenriz-desktop");
         ~Authenticator();
@@ -30,12 +37,13 @@ namespace fenriz::desktop {
         // Ignored while another attempt is in flight
         void submit_password(std::string_view password, Callback done);
 
-        // TODO: Fingerprint/face backends start here and race the password.
-        void begin_passive(Callback done);
+        // Starts every installed passive service (fingerprint, face) racing the password.
+        void begin_passive(Callback done, Status status = {});
 
-        // Abandons any in-flight attempt's result.
+        // Abandons any in-flight attempt's result, password and passive alike.
         void cancel();
 
+        // Is a password attempt in flight? Passive attempts do not count: they must not lock out the entry.
         bool busy() const;
 
         const std::string& service() const { return service_; }
@@ -43,6 +51,7 @@ namespace fenriz::desktop {
     private:
         std::string service_;
         std::shared_ptr<AuthAttempt> current_;
+        std::vector<std::shared_ptr<AuthAttempt>> passive_;
     };
 
 } // namespace fenriz::desktop

--- a/desktop/src/launcher.cpp
+++ b/desktop/src/launcher.cpp
@@ -1,5 +1,6 @@
 #include "launcher.hpp"
 
+#include <gio/gdesktopappinfo.h>
 #include <gtk4-layer-shell.h>
 
 #include <algorithm>
@@ -11,7 +12,8 @@ namespace fenriz::desktop {
     namespace {
         constexpr int WIDTH = 620;
         constexpr int HEIGHT = 420;
-        constexpr size_t MAX_ROWS = 50;
+
+        std::string str_or_empty(const char* s) { return s ? std::string(s) : std::string(); }
     } // namespace
 
     Launcher::Launcher(const Config& cfg) : cfg_(cfg) { usage_.load(); }
@@ -40,7 +42,19 @@ namespace fenriz::desktop {
             const char* name = g_app_info_get_display_name(info);
             if (!id || !name)
                 continue;
-            entries_.push_back(Entry{G_APP_INFO(g_object_ref(info)), id, name});
+
+            MatchFields f;
+            f.name = name;
+            f.comment = str_or_empty(g_app_info_get_description(info));
+            f.exec = str_or_empty(g_app_info_get_commandline(info));
+            if (G_IS_DESKTOP_APP_INFO(info)) {
+                auto* dinfo = G_DESKTOP_APP_INFO(info);
+                f.generic_name = str_or_empty(g_desktop_app_info_get_generic_name(dinfo));
+                // Borrowed, NULL-terminated, owned by the info.
+                for (const char* const* k = g_desktop_app_info_get_keywords(dinfo); k && *k; k++)
+                    f.keywords.emplace_back(*k);
+            }
+            entries_.push_back(Entry{G_APP_INFO(g_object_ref(info)), id, std::move(f)});
         }
         g_list_free_full(all, g_object_unref);
     }
@@ -50,22 +64,28 @@ namespace fenriz::desktop {
         const std::string query = raw ? raw : "";
         const int64_t now = now_ms();
 
+        // An empty query scores everything alike, leaving frecency to order the whole list.
+        std::vector<int> scores(entries_.size(), 0);
         shown_.clear();
         for (size_t i = 0; i < entries_.size(); i++) {
-            if (!query.empty() && !g_str_match_string(query.c_str(), entries_[i].name.c_str(), TRUE))
-                continue;
+            if (!query.empty()) {
+                const int s = match_score(entries_[i].fields, query);
+                if (s < 0)
+                    continue;
+                scores[i] = s;
+            }
             shown_.push_back(static_cast<int>(i));
         }
 
         std::stable_sort(shown_.begin(), shown_.end(), [&](int a, int b) {
+            if (scores[a] != scores[b])
+                return scores[a] > scores[b];
             const double fa = usage_.score_of(entries_[a].id, now);
             const double fb = usage_.score_of(entries_[b].id, now);
             if (fa != fb)
                 return fa > fb;
-            return entries_[a].name < entries_[b].name;
+            return g_utf8_collate(entries_[a].fields.name.c_str(), entries_[b].fields.name.c_str()) < 0;
         });
-        if (shown_.size() > MAX_ROWS)
-            shown_.resize(MAX_ROWS);
 
         gtk_list_box_remove_all(GTK_LIST_BOX(list_));
         for (int idx : shown_) {
@@ -80,7 +100,7 @@ namespace fenriz::desktop {
             gtk_image_set_pixel_size(GTK_IMAGE(icon), 28);
             gtk_box_append(GTK_BOX(box), icon);
 
-            GtkWidget* label = gtk_label_new(entries_[idx].name.c_str());
+            GtkWidget* label = gtk_label_new(entries_[idx].fields.name.c_str());
             gtk_label_set_xalign(GTK_LABEL(label), 0.0);
             gtk_widget_set_hexpand(label, TRUE);
             gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);

--- a/desktop/src/launcher.hpp
+++ b/desktop/src/launcher.hpp
@@ -7,10 +7,11 @@
 
 #include "config.hpp"
 #include "frecency.hpp"
+#include "search.hpp"
 
 namespace fenriz::desktop {
 
-    // Application launcher: desktop entries, matched by name and ranked by frecency.
+    // Application launcher: desktop entries, ranked by match quality then frecency.
     class Launcher {
     public:
         explicit Launcher(const Config& cfg);
@@ -26,7 +27,7 @@ namespace fenriz::desktop {
         struct Entry {
             GAppInfo* info = nullptr; // owned
             std::string id;
-            std::string name;
+            MatchFields fields;
         };
 
         void build(GtkApplication* app);

--- a/desktop/src/lock.cpp
+++ b/desktop/src/lock.cpp
@@ -20,7 +20,8 @@ namespace fenriz::desktop {
                    " transition: border-color 150ms; }"
                    ".lock-entry:focus-within { border-color: #cba6f7; }"
                    ".lock-entry.error { border-color: #f38ba8; }"
-                   ".lock-error { font-size: 14px; color: #ff8080; }";
+                   ".lock-error { font-size: 14px; color: #ff8080; }"
+                   ".lock-error.status { color: alpha(white, 0.85); }";
         }
 
     } // namespace
@@ -76,6 +77,13 @@ namespace fenriz::desktop {
         if (!tick_id_)
             tick_id_ = g_timeout_add_seconds(1, on_tick, this);
         tick();
+
+        auth_.begin_passive(
+            [this](bool ok, std::string) {
+                if (ok && instance_)
+                    gtk_session_lock_instance_unlock(instance_);
+            },
+            [this](std::string message) { set_status(message); });
     }
 
     void Lock::on_monitor(GtkSessionLockInstance*, GdkMonitor* monitor, gpointer data) {
@@ -186,14 +194,26 @@ namespace fenriz::desktop {
 
     void Lock::set_error(const std::string& text) {
         for (Surface& s : surfaces_) {
-            if (s.error)
+            if (s.error) {
                 gtk_label_set_text(GTK_LABEL(s.error), text.c_str());
+                gtk_widget_remove_css_class(s.error, "status");
+            }
             if (!s.entry)
                 continue;
             if (text.empty())
                 gtk_widget_remove_css_class(s.entry, "error");
             else
                 gtk_widget_add_css_class(s.entry, "error");
+        }
+    }
+
+    // What a passive method has to say ("Place your finger on the reader").
+    void Lock::set_status(const std::string& text) {
+        for (Surface& s : surfaces_) {
+            if (!s.error)
+                continue;
+            gtk_label_set_text(GTK_LABEL(s.error), text.c_str());
+            gtk_widget_add_css_class(s.error, "status");
         }
     }
 

--- a/desktop/src/lock.hpp
+++ b/desktop/src/lock.hpp
@@ -37,6 +37,7 @@ namespace fenriz::desktop {
         void submit(GtkWidget* entry);
         void tick();
         void set_error(const std::string& text);
+        void set_status(const std::string& text);
         void set_busy(bool busy);
 
         static void on_monitor(GtkSessionLockInstance* self, GdkMonitor* monitor, gpointer data);

--- a/desktop/src/search.cpp
+++ b/desktop/src/search.cpp
@@ -1,0 +1,73 @@
+#include "search.hpp"
+
+#include <glib.h>
+
+#include <algorithm>
+
+namespace fenriz::desktop {
+
+    namespace {
+
+        std::string casefold(const std::string& s) {
+            char* f = g_utf8_casefold(s.c_str(), -1);
+            std::string out = f ? f : std::string();
+            g_free(f);
+            return out;
+        }
+
+        bool is_word_break(char c) { return c == ' ' || c == '\t' || c == '-' || c == '_'; }
+
+        // Does any word of text start with query
+        bool any_word_starts_with(const std::string& text, const std::string& query) {
+            for (size_t i = 0; i < text.size();) {
+                while (i < text.size() && is_word_break(text[i]))
+                    i++;
+                if (i >= text.size())
+                    break;
+                if (text.compare(i, query.size(), query) == 0)
+                    return true;
+                while (i < text.size() && !is_word_break(text[i]))
+                    i++;
+            }
+            return false;
+        }
+
+    } // namespace
+
+    int score_match(const std::string& text, const std::string& query) {
+        if (text.empty() || query.empty())
+            return -1;
+
+        const std::string t = casefold(text);
+        const std::string q = casefold(query);
+
+        if (t == q)
+            return 1000;
+        if (t.compare(0, q.size(), q) == 0)
+            return 800;
+        if (any_word_starts_with(t, q))
+            return 600;
+        // A one or two character substring hits nearly everything, so it stays unranked.
+        if (g_utf8_strlen(q.c_str(), -1) >= 3 && t.find(q) != std::string::npos)
+            return 200;
+        return -1;
+    }
+
+    int match_score(const MatchFields& f, const std::string& query) {
+        int best = score_match(f.name, query);
+
+        for (const std::string& k : f.keywords)
+            if (const int s = score_match(k, query); s >= 0)
+                best = std::max(best, s - 20);
+        if (const int s = score_match(f.generic_name, query); s >= 0)
+            best = std::max(best, s - 50);
+        if (const int s = score_match(f.comment, query); s >= 0)
+            best = std::max(best, s - 100);
+
+        if (!f.exec.empty() && !query.empty() && casefold(f.exec).find(casefold(query)) != std::string::npos)
+            best = std::max(best, 180);
+
+        return best;
+    }
+
+} // namespace fenriz::desktop

--- a/desktop/src/search.hpp
+++ b/desktop/src/search.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace fenriz::desktop {
+
+    // Searchable text of one desktop entry.
+    struct MatchFields {
+        std::string name;
+        std::string generic_name;
+        std::string comment;
+        std::vector<std::string> keywords;
+        std::string exec;
+    };
+
+    // Relevance of one field: 1000 exact, 800 whole-string prefix, 600 word prefix,
+    // 200 substring, queries of 3+ characters only, -1 no match.
+    int score_match(const std::string& text, const std::string& query);
+
+    // Best score across an entry's fields, -1 when nothing matches. Higher is better.
+    int match_score(const MatchFields& f, const std::string& query);
+
+} // namespace fenriz::desktop

--- a/desktop/src/test_auth.cpp
+++ b/desktop/src/test_auth.cpp
@@ -10,6 +10,7 @@
 
 using fenriz::desktop::pam_result_unlocks;
 using fenriz::desktop::pam_service_installed;
+using fenriz::desktop::passive_services;
 
 namespace {
 
@@ -58,11 +59,27 @@ namespace {
             assert(pam_service_installed("other"));
     }
 
+    // Fingerprint and face are raced as separate PAM services, picked purely by whether their
+    // file exists. A bad name here either enables a method nobody installed or feeds
+    // pam_service_installed() something that is not a service name.
+    void test_passive_services() {
+        assert(!passive_services().empty());
+        for (const std::string& service : passive_services()) {
+            assert(!service.empty());
+            assert(service.find('/') == std::string::npos); // a path is not a service name
+
+            // The password service must not be in the list: it would run a second time with an
+            // empty secret, and a passive failure is deliberately not reported as a rejection.
+            assert(service != "fenriz-desktop");
+        }
+    }
+
 } // namespace
 
 int main() {
     test_only_success_unlocks();
     test_unknown_codes_deny();
     test_service_detection();
+    test_passive_services();
     return 0;
 }

--- a/desktop/src/test_search.cpp
+++ b/desktop/src/test_search.cpp
@@ -1,0 +1,113 @@
+#include <cassert>
+#include <string>
+
+#include "search.hpp"
+
+using namespace fenriz::desktop;
+
+namespace {
+
+    // The two entries that motivated field search: neither is reachable by its common name.
+    MatchFields gimp() {
+        return MatchFields{"GNU Image Manipulation Program",
+                           "Image Editor",
+                           "Create images and edit photographs",
+                           {"GIMP", "graphic", "design", "illustration", "painting"},
+                           "gimp-3.2 %U"};
+    }
+
+    MatchFields pavucontrol() {
+        return MatchFields{"Volume Control",
+                           "Volume Control",
+                           "Adjust the volume level",
+                           {"pavucontrol", "PulseAudio", "Microphone", "Volume", "Mixer", "Headphones"},
+                           "pavucontrol"};
+    }
+
+    void test_score_tiers() {
+        assert(score_match("Volume Control", "volume control") == 1000); // exact, case-folded
+        assert(score_match("Volume Control", "vol") == 800);             // whole string prefixed
+        assert(score_match("Volume Control", "cont") == 600);            // a later word prefixed
+        assert(score_match("Volume Control", "ume") == 200);             // substring only
+        assert(score_match("Volume Control", "zzz") == -1);
+
+        // Words also break on '-' and '_', not just whitespace.
+        assert(score_match("gimp-3.2", "3.2") == 600);
+        assert(score_match("qt5_settings", "settings") == 600);
+    }
+
+    // A one- or two-character substring matches almost every entry, so it must not rank.
+    void test_short_substring_does_not_match() {
+        assert(score_match("Volume Control", "ol") == -1);
+        assert(score_match("Volume Control", "o") == -1);
+        assert(score_match("Volume Control", "ume") == 200); // one more character and it does
+        // Short queries still work as prefixes.
+        assert(score_match("Volume Control", "v") == 800);
+        assert(score_match("Volume Control", "co") == 600);
+    }
+
+    void test_empty_inputs_never_match() {
+        assert(score_match("", "vol") == -1);
+        assert(score_match("Volume Control", "") == -1);
+        assert(match_score(pavucontrol(), "") == -1);
+    }
+
+    void test_gimp_is_reachable_by_its_real_name() {
+        // The whole point: "gimp" appears nowhere in Name, only in Keywords and Exec.
+        assert(match_score(gimp(), "gimp") == 980); // keyword exact, 1000 - 20
+        assert(match_score(gimp(), "gim") == 780);  // keyword prefix, 800 - 20
+        // The display name still matches as before.
+        assert(match_score(gimp(), "gnu") == 800);
+        assert(match_score(gimp(), "manip") == 600);
+        // GenericName and Comment carry their penalties.
+        assert(match_score(gimp(), "image") == 750);       // "Image Editor" prefix, 800 - 50
+        assert(match_score(gimp(), "editor") == 550);      // "Image Editor" word, 600 - 50
+        assert(match_score(gimp(), "photographs") == 500); // comment, 600 - 100
+        assert(match_score(gimp(), "libreoffice") == -1);
+    }
+
+    void test_pavucontrol_is_reachable_by_every_alias() {
+        assert(match_score(pavucontrol(), "pavu") == 780);        // keyword prefix
+        assert(match_score(pavucontrol(), "pavucontrol") == 980); // keyword exact
+        assert(match_score(pavucontrol(), "pulse") == 780);
+        assert(match_score(pavucontrol(), "mixer") == 980);
+        // An exact keyword hit (980) outranks a mere name prefix (800), as in quickshell.
+        assert(match_score(pavucontrol(), "volume") == 980);
+        assert(match_score(pavucontrol(), "control") == 600);
+        assert(match_score(pavucontrol(), "gimp") == -1);
+    }
+
+    // An entry only findable through its command line ranks below every readable field.
+    void test_exec_is_the_weakest_signal() {
+        const MatchFields wrapped{"Terminal", "", "", {}, "/usr/bin/env foot --server"};
+        assert(match_score(wrapped, "foot") == 180);
+        assert(match_score(wrapped, "term") == 800); // the name still outranks it
+        // Exec matches as a plain substring, with no length floor.
+        assert(match_score(wrapped, "oot") == 180);
+    }
+
+    void test_better_field_wins() {
+        // Same query, two entries: the one matching on Name must outscore the alias hit.
+        const MatchFields by_name{"Mixer", "", "", {}, "mixer"};
+        assert(match_score(by_name, "mixer") > match_score(pavucontrol(), "mixer"));
+    }
+
+    // Case folding is UTF-8 aware; accents are preserved
+    void test_folding_ignores_case() {
+        assert(score_match("LibreOffice Écrire", "libreoffice") == 800);
+        assert(score_match("LibreOffice Écrire", "ÉCRIRE") == 600);
+    }
+
+} // namespace
+
+int main() {
+    test_score_tiers();
+    test_short_substring_does_not_match();
+    test_empty_inputs_never_match();
+    test_gimp_is_reachable_by_its_real_name();
+    test_pavucontrol_is_reachable_by_every_alias();
+    test_exec_is_the_weakest_signal();
+    test_better_field_wins();
+    test_folding_ignores_case();
+    return 0;
+}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -493,7 +493,8 @@ namespace fenriz {
 
         output::register_handlers(*this);
 
-        xdg_shell = wlr_xdg_shell_create(display, 3);
+        // v4 for configure_bounds
+        xdg_shell = wlr_xdg_shell_create(display, 4);
         l_new_toplevel.server = this;
         add_listener(l_new_toplevel.listener, xdg_shell->events.new_toplevel, on_new_toplevel);
         l_new_popup.server = this;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -147,6 +147,18 @@ namespace fenriz {
             }
         }
 
+        // recommend the biggest window geometry that fits
+        void send_bounds(View* view) {
+            if (view->kind != View::Kind::Xdg || wl_resource_get_version(view->toplevel->resource) < 4)
+                return; // configure_bounds since v4
+            Server& server = *view->server;
+            const output::Area a = output::usable(server, output::focused(server));
+            if (a.width <= 0)
+                return;
+            const int bw = server.config.border_width;
+            wlr_xdg_toplevel_set_bounds(view->toplevel, a.width - 2 * bw, a.height - 2 * bw);
+        }
+
         // Single owner of a view's scene-tree parent
         void restack_view(Server& server, View* view) {
             if (!view->scene_tree)
@@ -314,6 +326,7 @@ namespace fenriz {
                 // Advertise tiled in the initial configure, before the client has drawn
                 // anything. (Chromium bug)
                 set_tiled(view, true);
+                send_bounds(view);
             }
 
             // the client has responded to our last size request, so its committed geometry can be trusted
@@ -763,8 +776,10 @@ namespace fenriz {
         const wlr_box a = view_area(server, view);
         if (a.width <= 0)
             return;
-        view->box.x = a.x + (a.width - view->box.width) / 2;
-        view->box.y = a.y + (a.height - view->box.height) / 2;
+        view->box.x =
+            std::clamp(a.x + (a.width - view->box.width) / 2, a.x, std::max(a.x, a.x + a.width - view->box.width));
+        view->box.y =
+            std::clamp(a.y + (a.height - view->box.height) / 2, a.y, std::max(a.y, a.y + a.height - view->box.height));
         place_view_nodes(view);
     }
 
@@ -882,9 +897,27 @@ namespace fenriz {
         const wlr_box geo = xdg ? view->toplevel->base->geometry
                                 : wlr_box{0, 0, view->xwl->surface->current.width, view->xwl->surface->current.height};
         if (view->floating && !view->fullscreen && geo.width > 0 && geo.height > 0 && cursor::grabbed_view() != view) {
-            const int bw = view->server->config.border_width;
+            Server& server = *view->server;
+            const int bw = server.config.border_width;
             view->box.width = geo.width + 2 * bw;
             view->box.height = geo.height + 2 * bw;
+            // client that asks for more than the screen holds would be too big
+            const wlr_box a = view_area(server, view);
+            if (a.width > 0 && (view->box.width > a.width || view->box.height > a.height)) {
+                int min_w, min_h, max_w, max_h;
+                view_min_size(view, min_w, min_h);
+                view_max_size(view, max_w, max_h);
+                const int fit_w = tiling::clamp_size(std::min(geo.width, a.width - 2 * bw), min_w, max_w);
+                const int fit_h = tiling::clamp_size(std::min(geo.height, a.height - 2 * bw), min_h, max_h);
+                if (fit_w < geo.width || fit_h < geo.height) {
+                    view->box.width = fit_w + 2 * bw;
+                    view->box.height = fit_h + 2 * bw;
+                    view->box.x = std::clamp(view->box.x, a.x, std::max(a.x, a.x + a.width - view->box.width));
+                    view->box.y = std::clamp(view->box.y, a.y, std::max(a.y, a.y + a.height - view->box.height));
+                    view->float_self_sized = false;
+                    view_configure(view);
+                }
+            }
             // A window-rule center can only run once the float has its real size (now).
             if (view->want_center) {
                 center_view(*view->server, view);


### PR DESCRIPTION
fix: clients who request sizes out-of-bounds are allowed it in floating. Clamp. fixes #17 
feat: pam auth modules: fprintd, gaze