### PR TITLE
feat: workspace switch bezier fade

### DIFF
--- a/defaults/fenriz.conf
+++ b/defaults/fenriz.conf
@@ -26,7 +26,7 @@ gaps             = 8
 # margin         = 0             # inset from the screen edges in px. One value = all sides,
                                  # two = vertical horizontal, four = top right bottom left.
 rounding         = 10            # corner radius in px
-animation        = 150           # window slide-into-place, ms; 0 = instant (off)
+animation        = 150           # window slide-into-place + workspace fade, ms; 0 = instant (off)
 opacity          = 0.95          # 0.0..1.0
 scale            = auto          # auto = guess each screen's scale from its DPI (1x/1.5x/2x).
                                  # A number here forces every screen to it; the per-output

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -123,7 +123,7 @@ Colors are `0xRRGGBBAA` hex.
 | `gaps` | `8` | gap between windows, px |
 | `margin` | `0` | inset from the screen edges, px. One value = all sides, two = vertical horizontal, four = top right bottom left |
 | `rounding` | `10` | corner radius, px |
-| `animation` | `150` | slide-into-place duration, ms; `0` = off |
+| `animation` | `150` | slide-into-place and workspace-switch fade duration, ms; `0` = off |
 | `opacity` | `1.0` | window opacity, `0.0`–`1.0` |
 
 ### Input

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -25,17 +25,15 @@ namespace fenriz::output {
         // layer-shell wallpaper. wlr_scene otherwise clears uncovered regions to black.
         constexpr float BG[4] = {0.1f, 0.1f, 0.12f, 1.0f};
 
-        // Advance the slide-into-place animation: decay each visible view's render offset
-        // toward 0 by an exponential factor scaled to the elapsed frame time (so the speed
-        // is independent of refresh rate), pushing the result into its scene node.
+        // Advance every animation running on this output by the elapsed frame time , pushing result into the scene
+        // nodes.
         bool animate(Output* output, const timespec& now) {
             Server& server = *output->server;
             double dt = (now.tv_sec - output->last_frame.tv_sec) + (now.tv_nsec - output->last_frame.tv_nsec) / 1e9;
             output->last_frame = now;
             if (dt <= 0 || dt > 1.0)
                 dt = 1.0 / 60; // first frame or a long stall: assume one 60Hz tick
-            const double tau = std::max(1, server.config.animation_ms) / 1000.0 * 0.35;
-            const double factor = std::exp(-dt / tau);
+            const double step = dt / (std::max(1, server.config.animation_ms) / 1000.0);
             bool animating = false;
             for (View* view : server.views) {
                 if (!view_visible(server, view) || view_output(server, view) != output)
@@ -45,23 +43,22 @@ namespace fenriz::output {
                     place_view_nodes(view); // keep the held window under the cursor each frame
                     continue;
                 }
-                if (view->anim_ox != 0 || view->anim_oy != 0) {
-                    view->anim_ox *= factor;
-                    view->anim_oy *= factor;
-                    if (std::abs(view->anim_ox) < 1 && std::abs(view->anim_oy) < 1)
-                        view->anim_ox = view->anim_oy = 0;
-                    else
+                if (view->anim_t < 1.0) {
+                    view->anim_t = std::min(1.0, view->anim_t + step);
+                    const double left = 1.0 - ease_out(view->anim_t); // offset still to travel
+                    view->anim_ox = view->anim_sx * left;
+                    view->anim_oy = view->anim_sy * left;
+                    if (view->anim_t < 1.0)
                         animating = true;
                     place_view_nodes(view);
                 }
             }
 
             // Ease the workspace-switch fade up to full.
-            if (output->ws_fade < 1.0) {
-                output->ws_fade = 1.0 - (1.0 - output->ws_fade) * factor;
-                if (output->ws_fade > 0.99)
-                    output->ws_fade = 1.0;
-                else
+            if (output->ws_fade_t < 1.0) {
+                output->ws_fade_t = std::min(1.0, output->ws_fade_t + step);
+                output->ws_fade = ease_out(output->ws_fade_t);
+                if (output->ws_fade_t < 1.0)
                     animating = true;
                 for (View* view : server.views)
                     if (view_visible(server, view) && view_output(server, view) == output)
@@ -174,7 +171,7 @@ namespace fenriz::output {
                 tiling::arrange(server, false);
             }
 
-            // Ease the global zoom level toward its target only on the output holding the cursor
+            // Ease the global zoom level toward its target only on the output holding the cursor.
             const bool has_cursor =
                 wlr_output_layout_output_at(server.output_layout, server.cursor->x, server.cursor->y) == output->handle;
             bool zoom_animating = false;
@@ -197,7 +194,7 @@ namespace fenriz::output {
             // Only commit when the scene needs a repaint, a gamma LUT change is pending, or a
             // zoom is active/animating/just-ended here. An idle, unchanged output commits nothing.
             if (wlr_scene_output_needs_frame(so) || output->gamma_dirty || zoomed || zoom_animating || exiting_zoom ||
-                output->ws_fade < 1.0) {
+                output->ws_fade_t < 1.0) {
                 // (Re)apply SceneFX per-window effects right before rendering. scenefx re-syncs
                 // each surface buffer during its own commit handling (after our commit handler), resetting opacity
                 // to 1.0
@@ -248,9 +245,7 @@ namespace fenriz::output {
             wlr_scene_node_set_position(&o->bg->node, box.x, box.y);
         }
 
-        // Close (client-side) every layer surface anchored to this output before it goes away,
-        // rather than waiting for the client to notice the wl_output global vanish — otherwise a
-        // bar outlives its screen and layer::arrange keeps walking a dangling handle->output.
+        // Close every layer surface anchored to this output before it goes away
         void close_layer_surfaces(Server& server, wlr_output* handle) {
             for (LayerSurface* ls : std::list<LayerSurface*>(server.layer_surfaces))
                 if (ls->handle->output == handle)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -55,6 +55,18 @@ namespace fenriz::output {
                     place_view_nodes(view);
                 }
             }
+
+            // Ease the workspace-switch fade up to full.
+            if (output->ws_fade < 1.0) {
+                output->ws_fade = 1.0 - (1.0 - output->ws_fade) * factor;
+                if (output->ws_fade > 0.99)
+                    output->ws_fade = 1.0;
+                else
+                    animating = true;
+                for (View* view : server.views)
+                    if (view_visible(server, view) && view_output(server, view) == output)
+                        place_view_nodes(view);
+            }
             return animating;
         }
 
@@ -184,7 +196,8 @@ namespace fenriz::output {
 
             // Only commit when the scene needs a repaint, a gamma LUT change is pending, or a
             // zoom is active/animating/just-ended here. An idle, unchanged output commits nothing.
-            if (wlr_scene_output_needs_frame(so) || output->gamma_dirty || zoomed || zoom_animating || exiting_zoom) {
+            if (wlr_scene_output_needs_frame(so) || output->gamma_dirty || zoomed || zoom_animating || exiting_zoom ||
+                output->ws_fade < 1.0) {
                 // (Re)apply SceneFX per-window effects right before rendering. scenefx re-syncs
                 // each surface buffer during its own commit handling (after our commit handler), resetting opacity
                 // to 1.0

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -22,16 +22,13 @@ namespace fenriz {
             int x, y, width, height;
         };
 
-        // Per-output state. Standard-layout, so wl_container_of recovers it cleanly from the
-        // embedded wl_listeners — keep it that way (no virtuals, no private sections).
+        // Per-output state
         struct Output {
             Server* server = nullptr;
             wlr_output* handle = nullptr;
             wlr_scene_rect* bg = nullptr; // full-output backdrop in the background tree
 
-            // Which workspace is shown here; -1 = none (no workspace assigned to this output).
-            // A workspace can *live* on an output (Workspace::output) without being the one
-            // shown — that's this field.
+            // Which workspace is shown here; -1 = none. A workspace can live on an output without being the one shown.
             int active_ws = -1;
 
             // Tiling region left after this output's layer-shell exclusive zones (bars) are
@@ -45,6 +42,10 @@ namespace fenriz {
             wl_listener request_state;
             wl_listener destroy;
             timespec last_frame{}; // for frame-rate-independent animation decay
+
+            // Workspace-switch fade: alpha multiplier for this output's windows, eased 0 -> 1 after a switch. 1.0 =
+            // settled, no fade in progress.
+            double ws_fade = 1.0;
 
             // Offscreen buffers the scene renders into while this output is zoomed; the frame
             // is then blitted scaled to fill the output. Null unless zoom is/was active here.

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -22,6 +22,16 @@ namespace fenriz {
             int x, y, width, height;
         };
 
+        // Change 0..1 animation progress into a 0..1 eased fraction
+        inline double ease_out(double t) {
+            if (t <= 0.0)
+                return 0.0;
+            if (t >= 1.0)
+                return 1.0;
+            const double k = 1.0 - t;
+            return 1.0 - k * k * k;
+        }
+
         // Per-output state
         struct Output {
             Server* server = nullptr;
@@ -43,9 +53,9 @@ namespace fenriz {
             wl_listener destroy;
             timespec last_frame{}; // for frame-rate-independent animation decay
 
-            // Workspace-switch fade: alpha multiplier for this output's windows, eased 0 -> 1 after a switch. 1.0 =
-            // settled, no fade in progress.
+            // Workspace-switch fade. ws_fade is the alpha multiplier this output's windows render with
             double ws_fade = 1.0;
+            double ws_fade_t = 1.0;
 
             // Offscreen buffers the scene renders into while this output is zoomed; the frame
             // is then blitted scaled to fill the output. Null unless zoom is/was active here.

--- a/src/test_output.cpp
+++ b/src/test_output.cpp
@@ -358,6 +358,24 @@ int main() {
         assert(std::abs(zoom_viewport_origin(W, 4.0) - (W - W / 4)) < 1e-9);
     }
 
+    {
+        // The animation curve. An inverted or overshooting ease would leave windows sliding
+        // the wrong way or landing past their tile, and a curve that misses its endpoints
+        // would strand a fade below full opacity.
+        assert(ease_out(0.0) == 0.0);
+        assert(ease_out(1.0) == 1.0);
+        assert(ease_out(-1.0) == 0.0); // clamped, never negative
+        assert(ease_out(2.0) == 1.0);
+        double prev = -1.0;
+        for (int i = 0; i <= 100; i++) {
+            const double e = ease_out(i / 100.0);
+            assert(e > prev);             // strictly increasing: no stall, no reversal
+            assert(e >= 0.0 && e <= 1.0); // no overshoot past the target
+            prev = e;
+        }
+        assert(ease_out(0.5) > 0.5); // front-loaded: most of the distance covered early
+    }
+
     printf("test_output: ok\n");
     return 0;
 }

--- a/src/tiling.cpp
+++ b/src/tiling.cpp
@@ -88,10 +88,8 @@ namespace fenriz::tiling {
                 // that weren't placed yet (new maps: box.width == 0) so they don't fly in.
                 const View::Box old = view->box;
                 view->box = {n->rect.x, n->rect.y, n->rect.w, n->rect.h};
-                if (animate && server.config.animation_ms > 0 && old.width > 0) {
-                    view->anim_ox += old.x - view->box.x;
-                    view->anim_oy += old.y - view->box.y;
-                }
+                if (animate && server.config.animation_ms > 0 && old.width > 0)
+                    anim_slide(view, old.x - view->box.x, old.y - view->box.y);
                 view_configure(view); // size the client to the inner tile area (shell-agnostic)
             }
         }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -32,6 +32,13 @@ namespace fenriz {
             out[3] = a;
         }
 
+        // Scale a color's opacity. Every component moves: the RGB is premultiplied, so touching only alpha would leave
+        // the color over-bright.
+        void fade_color(float c[4], float fade) {
+            for (int i = 0; i < 4; i++)
+                c[i] *= fade;
+        }
+
         // ramp resolution
         constexpr int GRAD_N = 17;
 
@@ -131,6 +138,8 @@ namespace fenriz {
                 if (const wlr_alpha_modifier_surface_v1_state* am =
                         wlr_alpha_modifier_v1_get_surface_state(ss->surface))
                     alpha *= (float)am->multiplier;
+            if (const output::Output* o = view_output(s, v))
+                alpha *= (float)o->ws_fade; // workspace-switch fade
             wlr_scene_buffer_set_opacity(buf, alpha);
         }
 
@@ -1032,6 +1041,10 @@ namespace fenriz {
             return;
         }
 
+        // Decorations fade with the content, or they'd pop in at full strength in front of a window that isn't there
+        // yet.
+        const float fade = (float)server.workspaces[view->workspace].output->ws_fade;
+
         const int bw = view->fullscreen ? 0 : server.config.border_width;
 
         // The tile, plus the (decaying) slide-animation offset. Only the position animates:
@@ -1112,6 +1125,7 @@ namespace fenriz {
             wlr_scene_rect_set_clipped_region(view->border, hole);
             float col[4];
             u32_color(view == server.focused_view ? server.config.border_active : server.config.border_inactive, col);
+            fade_color(col, fade);
             wlr_scene_rect_set_color(view->border, col);
         }
 
@@ -1145,6 +1159,7 @@ namespace fenriz {
                      .corners = hole.corners});
                 float col[4];
                 u32_color(corner_rgba[i], col);
+                fade_color(col, fade);
                 wlr_scene_rect_set_color(n, col);
             }
 
@@ -1166,6 +1181,7 @@ namespace fenriz {
                 }
                 if (band[i].width <= 0 || band[i].height <= 0)
                     continue;
+                wlr_scene_buffer_set_opacity(n, fade);
                 wlr_scene_node_set_position(&n->node, band[i].x, band[i].y);
                 wlr_scene_buffer_set_dest_size(n, band[i].width, band[i].height);
                 const wlr_fbox src = grad_src(band[i].x, band[i].y, band[i].width, band[i].height, W, H);
@@ -1186,6 +1202,7 @@ namespace fenriz {
             float scol[4];
             u32_color(glow_rgba, scol);
             scol[3] = (server.config.shadow_color & 0xff) / 255.0f;
+            fade_color(scol, fade);
             wlr_scene_shadow_set_color(view->shadow, scol);
             wlr_scene_shadow_set_blur_sigma(view->shadow, (float)server.config.shadow_blur);
             wlr_scene_shadow_set_size(view->shadow, box.width, box.height);
@@ -1214,7 +1231,14 @@ namespace fenriz {
         }
 
         // The workspace that output was showing steps aside; this one takes its place.
+        const bool switched = o->active_ws != n;
         o->active_ws = n;
+
+        // Fade the incoming workspace up rather than swapping it in between two frames.
+        if (switched && server.config.animation_ms > 0) {
+            o->ws_fade = 0.0;
+            wlr_output_schedule_frame(o->handle);
+        }
 
         // Pinned floats follow the output to whatever workspace it now shows.
         for (View* v : server.views)

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -785,10 +785,8 @@ namespace fenriz {
                     center_view(server, v);
                 }
                 v->float_self_sized = false;
-                if (server.config.animation_ms > 0 && old.width > 0) {
-                    v->anim_ox += old.x - v->box.x;
-                    v->anim_oy += old.y - v->box.y;
-                }
+                if (server.config.animation_ms > 0 && old.width > 0)
+                    anim_slide(v, old.x - v->box.x, old.y - v->box.y);
                 view_configure(v);
             }
         } else {
@@ -1237,6 +1235,7 @@ namespace fenriz {
         // Fade the incoming workspace up rather than swapping it in between two frames.
         if (switched && server.config.animation_ms > 0) {
             o->ws_fade = 0.0;
+            o->ws_fade_t = 0.0;
             wlr_output_schedule_frame(o->handle);
         }
 

--- a/src/view.hpp
+++ b/src/view.hpp
@@ -25,14 +25,10 @@ namespace fenriz {
         struct Output;
     }
 
-    // A managed window: wraps an xdg_toplevel and its tiled geometry. Standard-layout
-    // (pointers + POD + wl_listener only) so wl_container_of recovers it cleanly.
+    // A managed window: wraps an xdg_toplevel and its tiled geometry.
     class View {
     public:
-        // Which shell this window came from. Xdg is a Wayland-native toplevel; Xwl is an
-        // XWayland (X11) surface. Exactly one of `toplevel`/`xwl` is set; the free functions
-        // below (view_surface/view_app_id/…) branch on this so the tiling/focus/render path
-        // stays shell-agnostic.
+        // Which shell this window came from. Xdg is a Wayland-native toplevel; Xwl is an XWayland (X11) surface.
         enum class Kind { Xdg, Xwl };
 
         View(Server& server, wlr_xdg_toplevel* toplevel);
@@ -65,10 +61,10 @@ namespace fenriz {
 
         bool configure_pending = false;
 
-        // Render offset from box, in logical coords; decays to 0 each frame for the
-        // slide-into-place animation (see output.cpp). `dragging` holds the offset
-        // (no decay) while the window tracks the cursor, and draws it above the tiles.
+        // Render offset from box, in logical coords
         double anim_ox = 0, anim_oy = 0;
+        double anim_sx = 0, anim_sy = 0;
+        double anim_t = 1.0;
         bool dragging = false;
 
         // wlr-foreign-toplevel handle (taskbar/window-list protocol); live while mapped.
@@ -81,15 +77,8 @@ namespace fenriz {
         // activate or close), so it runs alongside foreign_handle rather than replacing it.
         wlr_ext_foreign_toplevel_handle_v1* ext_foreign_handle = nullptr;
 
-        // Scene nodes, created on map (see view_handle_map). scene_tree is the container
-        // positioned at the tile origin; surface_tree holds the xdg surface (inset by the
-        // border); border is the frame rect.
-        //
-        // popup_tree is a sibling of surface_tree, not a child, and shares its origin (both
-        // sit at the inner border corner, which is the window-geometry top-left the popup
-        // protocol positions against). Popups must live outside surface_tree because the
-        // toplevel's clip and content effects both sweep that subtree wholesale — a popup
-        // parented under it inherits the parent's clip box and corner radius.
+        // Scene nodes, created on map. scene_tree is the container
+        // positioned at the tile origin; surface_tree holds the xdg surface
         wlr_scene_tree* scene_tree = nullptr;
         wlr_scene_tree* surface_tree = nullptr;
         wlr_scene_tree* popup_tree = nullptr;
@@ -188,6 +177,15 @@ namespace fenriz {
     // Focus the nearest visible view whose center lies in direction (dx,dy), each in
     // {-1,0,1}: left (-1,0), right (1,0), up (0,-1), down (0,1). No-op if none.
     void focus_direction(Server& server, int dx, int dy);
+
+    // (re)start the slide-into-place ease
+    inline void anim_slide(View* v, int dx, int dy) {
+        v->anim_ox += dx;
+        v->anim_oy += dy;
+        v->anim_sx = v->anim_ox;
+        v->anim_sy = v->anim_oy;
+        v->anim_t = 0.0;
+    }
 
     // A view is shown only when mapped and its workspace is the one currently shown on the
     // output that workspace lives on. A workspace on no output (all screens gone) shows


### PR DESCRIPTION
`animation` now applies to a bezier curve fade when switching workspaces. This just reduces the slightly jarring thunk of workspaces switching without slowing you down at all.